### PR TITLE
Do not chown mounted filesystems

### DIFF
--- a/jobs/nfsv3driver/templates/ctl.erb
+++ b/jobs/nfsv3driver/templates/ctl.erb
@@ -30,7 +30,7 @@ case $1 in
     chmod 777 /var/vcap/data/voldrivers
 
     mkdir -p "<%= p("nfsv3driver.cell_mount_path") %>"
-    chown -R cvcap:cvcap "<%= p("nfsv3driver.cell_mount_path") %>"
+    chown cvcap:cvcap "<%= p("nfsv3driver.cell_mount_path") %>"
 
     export GOMAXPROCS=$(nproc)
 


### PR DESCRIPTION
This fixes the condition where the nfsv3driver process fails and cannot
be restarted.  This happens when the nfsv3driver.cell_mount_path already
exists and has mounts under it, and then tries to chown everything under
it to cvcap:cvcap, which probably doesn't exist on the remote systems.

This is fixed by simply removing the recursive flag (-R) from the chown
command.  There should be no negative impact by this change because
everything under this path is a remote mount.