### PR TITLE
nfsv3driver: Put the shared libs in /usr/lib64 where appropriate

### DIFF
--- a/jobs/nfsv3driver/templates/install.erb
+++ b/jobs/nfsv3driver/templates/install.erb
@@ -2,6 +2,9 @@
 
 set -e -x
 
+# Figure out where the libraries should be installed.
+libdir="/usr/$(dirname "$(ldconfig -p | awk '/libc.so/ { print $NF }')")"
+
 # make sure there arent any existing fuse-nfs mounts
 pkill fuse-nfs | true
 for i in {1..60}; do
@@ -19,14 +22,14 @@ mkdir -p /var/vcap/packages/fuse-nfs/bin
 chown vcap /var/vcap/packages/fuse-nfs/bin || true
 
 pushd /var/vcap/packages/fuse-nfs/fuse-2.9.2
-cp lib/.libs/*.so /usr/lib
+cp lib/.libs/*.so "${libdir}"
 cp util/fusermount /var/vcap/packages/fuse-nfs/bin
 chmod u+s /var/vcap/packages/fuse-nfs/bin/fusermount
 popd
 
 echo "Copying libnfs Shared Objects"
 pushd /var/vcap/packages/fuse-nfs/libnfs-1.11.0
-cp -d lib/.libs/libnfs.so* /usr/lib
+cp -d lib/.libs/libnfs.so* "${libdir}"
 popd
 
 echo "Adding fuse-nfs to PATH"


### PR DESCRIPTION
Hi there!

Some Linux distributions (SUSE, RedHat) use `/usr/lib64` instead of `/usr/lib` (as found on Debian/Ubuntu).  Stemcells built with those would not find the hand-installed NFS libraries in that case.

Fix this by attempting to detect where the libraries should go (based on where `libc` lives), and copy the files to the appropriate directory.

The fix was inspired by the comments in https://issues.asterisk.org/jira/browse/ASTERISK-26909; a solution based on `/usr/share/site` would be better, but we can't assume that exists in a stemcell.

Thanks for reading :)