### PR TITLE
Make nfsbroker app memory configurable

### DIFF
--- a/jobs/nfsbrokerpush/spec
+++ b/jobs/nfsbrokerpush/spec
@@ -31,6 +31,9 @@ properties:
     description: 'Organization that hosts the app'
   nfsbrokerpush.space:
     description: 'Space that hosts the app'
+  nfsbrokerpush.memory_in_mb:
+    description: 'Amount of memory allocated to the broker app'
+    default: 256
   nfsbrokerpush.username:
     description: 'service broker username'
   nfsbrokerpush.password:

--- a/jobs/nfsbrokerpush/templates/manifest.yml.erb
+++ b/jobs/nfsbrokerpush/templates/manifest.yml.erb
@@ -14,6 +14,7 @@
 %>
   buildpack: binary_buildpack
   domain: "<%= p('nfsbrokerpush.app_domain') %>"
+  memory: "<%= p('nfsbrokerpush.memory_in_mb') %>M"
   env:
     GOPACKAGENAME: nfsbroker
     GOVERSION: go1.7


### PR DESCRIPTION
- Allows us to override the platform default of 1GB for better resource
  utilization
- Defaults to 256MB

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>