### PR TITLE
Prevent GO111MODULE from breaking vendoring

### DIFF
--- a/dockerfiles/nfs-unit-tests/Dockerfile
+++ b/dockerfiles/nfs-unit-tests/Dockerfile
@@ -19,5 +19,4 @@ ENV GOPATH /go
 ENV GOROOT=/usr/local/go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-ENV GO111MODULE=on
-RUN go get github.com/onsi/ginkgo/ginkgo@$(cat /tmp/ginkgo_version)
+RUN GO111MODULE=on go get github.com/onsi/ginkgo/ginkgo@$(cat /tmp/ginkgo_version)


### PR DESCRIPTION
* Run only the go get ginkgo in gomod mode

This package vendors its dependencies pinning them to specific
versions. If we enable gomod mode pinned versions are ignored
and latest version is retrieved instead breaking CI