### PR TITLE
Use globally installed ginkgo when available

### DIFF
--- a/scripts/ci/run_docker_driver_integration_tests
+++ b/scripts/ci/run_docker_driver_integration_tests
@@ -17,7 +17,11 @@ SOURCE="localhost:/"
 export SOURCE
 export GOROOT=/usr/local/go
 export PATH=$GOROOT/bin:$PATH
-go get -u github.com/onsi/ginkgo/ginkgo
+
+if ! ginkgo version &> /dev/null
+then
+  go get -u github.com/onsi/ginkgo/ginkgo
+fi
 
 pushd mapfs-release
   export PATH=$PWD/bin:$PATH


### PR DESCRIPTION
Latest versions of ginkgo require a newer version of golang.
Also, installing a specific version of ginkgo is not easy without using
go module system and it doesn't play well with vendored packages anyway.

Since this script is specifically designed to run on CI with cfpersi/nfs-integration-tests
image which contains a globally installed version of Ginkgo try to use it instead:
This change goes hand in hand with cloudfoundry/nfs-volume-release#67

But if for whatever reason ginkgo cli couldn't be found fallback to preexisting logic
and try to install latest version of ginkgo with `go get`