### PR TITLE
Use globally installed ginkgo when available

### DIFF
--- a/scripts/ci/run_driver_unit
+++ b/scripts/ci/run_driver_unit
@@ -11,6 +11,9 @@ export PATH=$GOROOT/bin:$PATH
 export GOPATH=$PWD
 export PATH=$PWD/bin:$PATH
 
-go get -u github.com/onsi/ginkgo/ginkgo
+if ! ginkgo version &> /dev/null
+then
+  go get -u github.com/onsi/ginkgo/ginkgo
+fi
 
 ./scripts/run-driver-unit-tests -race


### PR DESCRIPTION
Latest versions of ginkgo require a newer version of golang.
Also, installing a specific version of ginkgo is not easy without using
go module system and it doesn't play well with vendored packages anyway.

Since this script is specifically designed to run on CI with cfpersi/nfs-unit-tests
image which contains a globally installed version of Ginkgo try to use it instead:
This change goes hand in hand with #69

But if for whatever reason ginkgo cli couldn't be found fallback to preexisting logic
and try to install latest version of ginkgo with go get