### PR TITLE
Adds both bionic and focal support

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -16,30 +16,18 @@ nfs-debs/libgssapi-krb5-2_1.15.1-2_amd64.deb:
   size: 120298
   object_id: 00800a67-3797-4f5a-6cf5-e2f8a4290d85
   sha: sha256:07affb4998cbd57d9d125349213cde5a191a5bb466f9085333c87d2a6b252648
-nfs-debs/libgssapi-krb5-2_1.16-2ubuntu0.2_amd64.deb:
-  size: 122004
-  sha: sha256:dbb4d6508d81ac50b9f3fbac9f1d0d00c9ad15d22bce104ebf934813d780012b
 nfs-debs/libk5crypto3_1.15.1-2_amd64.deb:
   size: 84942
   object_id: 461520bc-8f33-4c19-7f13-fffa143614cb
   sha: sha256:f52e197b56ddfa20159a9f4967b87dc29a1987ea4a48acd159512761c4ae51e4
-nfs-debs/libk5crypto3_1.16-2ubuntu0.2_amd64.deb:
-  size: 85472
-  sha: sha256:d3cf88802e2a182ccd2214c454adda9fd895d35d73c9cda2c7ce53e5356c1927
 nfs-debs/libkrb5-3_1.15.1-2_amd64.deb:
   size: 276254
   object_id: e8d2e2aa-647a-45fd-53f1-b8d1199718b3
   sha: sha256:6613a940c56a785724e330645fd9ac9bf493b849cbb63c541b7a6ce1b426a99d
-nfs-debs/libkrb5-3_1.16-2ubuntu0.2_amd64.deb:
-  size: 278652
-  sha: sha256:43344f93c620dbaa9d3941cbad6900492273c609a728739dc68d816ca23a5df0
 nfs-debs/libkrb5support0_1.15.1-2_amd64.deb:
   size: 32158
   object_id: 721c58f2-7b41-4736-40f0-9fc36ea629c6
   sha: sha256:da7fd6c191485c6c64b484368a77f3cbbe2d0729f858045ea4182df09f77ba3a
-nfs-debs/libkrb5support0_1.16-2ubuntu0.2_amd64.deb:
-  size: 30824
-  sha: sha256:f09c0d595dc9124716bfdb250329335e18efb8840982dd1191d49c6f214f7dbf
 nfs-debs/libnfsidmap2_0.25-5.1_amd64.deb:
   size: 27180
   sha: sha256:ae6eaf479efa010b313b4e0cf18812e3ca6eb50b6392b7b52e854d6acafe866b
@@ -51,9 +39,6 @@ nfs-debs/libtirpc1_0.2.5-1.2+deb9u1_amd64.deb:
   size: 80634
   object_id: 671095cf-0251-4aab-63a8-ee86f9ec150d
   sha: sha256:2176796081db99169c578dbfc1d958e2170047be7bff9722350204953623be44
-nfs-debs/libtirpc1_0.2.5-1.2ubuntu0.1_amd64.deb:
-  size: 75708
-  sha: sha256:6e0e12526d37f786f7afec3e16a1b5687d97774fdc9596bc8f42291214df2a5d
 nfs-debs/nfs-common_1.3.4-2.1ubuntu4_amd64.deb:
   size: 205360
   object_id: 79011511-3a38-4446-4521-c05ff6ecfc63

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -9,9 +9,15 @@ nfs-debs/keyutils_1.5.9-8ubuntu1_amd64.deb:
 nfs-debs/keyutils_1.5.9-9.2ubuntu2_amd64.deb:
   size: 47896
   sha: sha256:223a7160b6e2680d2b1f43abb067e0ccc08906bb2c5448ad4b3065f38309bbb5
+nfs-debs/keyutils_1.6-6ubuntu1_amd64.deb:
+  size: 44960
+  sha: sha256:ae5fd32e1ee1ff359b187e6b410c6ec6eac2c967bc24bd68bc07c7700b874ccc
 nfs-debs/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb:
   size: 133328
   sha: sha256:76bc94b3bb4356673c61dd2a4a7b06f40de21dab051aa4b31282aa9d7798b383
+nfs-debs/libevent-2.1-7_2.1.11-stable-1_amd64.deb:
+  size: 138008
+  sha: sha256:4494b16a4732e6d9989d440bcedac846cee66bc11cc55c1f622b0abb7d6c449f
 nfs-debs/libgssapi-krb5-2_1.15.1-2_amd64.deb:
   size: 120298
   object_id: 00800a67-3797-4f5a-6cf5-e2f8a4290d85
@@ -31,6 +37,9 @@ nfs-debs/libkrb5support0_1.15.1-2_amd64.deb:
 nfs-debs/libnfsidmap2_0.25-5.1_amd64.deb:
   size: 27180
   sha: sha256:ae6eaf479efa010b313b4e0cf18812e3ca6eb50b6392b7b52e854d6acafe866b
+nfs-debs/libnfsidmap2_0.25-5.1ubuntu1_amd64.deb:
+  size: 27852
+  sha: sha256:5ffcd9d6cc05b5e2f6e952a02e9308bf9c9aa35a11a4f683d474c27f44d7276e
 nfs-debs/libnfsidmap2_0.25-5_amd64.deb:
   size: 32182
   object_id: d666fb5d-2e46-4bb1-6dba-b2e6368c6048
@@ -46,6 +55,9 @@ nfs-debs/nfs-common_1.3.4-2.1ubuntu4_amd64.deb:
 nfs-debs/nfs-common_1.3.4-2.1ubuntu5.3_amd64.deb:
   size: 205520
   sha: sha256:ecf4d9601d210d86d423457dd18a7d3af406ed34a273fb22ade431764fc66d67
+nfs-debs/nfs-common_1.3.4-2.5ubuntu3.3_amd64.deb:
+  size: 204084
+  sha: sha256:aa77347fd0ba3b4845de717bc80db0240a2bc7b98082a7100118b122653c2b93
 nfs-debs/rpcbind_0.2.3-0.6_amd64.deb:
   size: 45966
   object_id: 34ce9d16-81b5-4f83-6e52-14259e667a38
@@ -53,6 +65,9 @@ nfs-debs/rpcbind_0.2.3-0.6_amd64.deb:
 nfs-debs/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb:
   size: 42124
   sha: sha256:ad1e5849523af0dba54a1f7e7f54d11f1a7a0131ce5de858a5ff37e61c27b35d
+nfs-debs/rpcbind_1.2.5-8_amd64.deb:
+  size: 42836
+  sha: sha256:f67c7baa1b76ba3ad682c00899ec71c73bdeb3c2dd2bf73251f971f51673beab
 openldap/openldap-2.4.44.tgz:
   size: 5658830
   object_id: daea5917-02c3-4fe5-4626-a8805979788d

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -6,26 +6,43 @@ nfs-debs/keyutils_1.5.9-8ubuntu1_amd64.deb:
   size: 47054
   object_id: 79ec8102-01f0-4e62-7d5a-cac385c29c03
   sha: ec2e96e73feb5215605c9f0254cad05d9cc5688a
+nfs-debs/keyutils_1.5.9-9.2ubuntu2_amd64.deb:
+  size: 47896
+  sha: sha256:223a7160b6e2680d2b1f43abb067e0ccc08906bb2c5448ad4b3065f38309bbb5
 nfs-debs/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb:
   size: 133328
-  object_id: c1fc2753-6049-4791-4233-3bb002100204
   sha: sha256:76bc94b3bb4356673c61dd2a4a7b06f40de21dab051aa4b31282aa9d7798b383
 nfs-debs/libgssapi-krb5-2_1.15.1-2_amd64.deb:
   size: 120298
   object_id: 00800a67-3797-4f5a-6cf5-e2f8a4290d85
   sha: sha256:07affb4998cbd57d9d125349213cde5a191a5bb466f9085333c87d2a6b252648
+nfs-debs/libgssapi-krb5-2_1.16-2ubuntu0.2_amd64.deb:
+  size: 122004
+  sha: sha256:dbb4d6508d81ac50b9f3fbac9f1d0d00c9ad15d22bce104ebf934813d780012b
 nfs-debs/libk5crypto3_1.15.1-2_amd64.deb:
   size: 84942
   object_id: 461520bc-8f33-4c19-7f13-fffa143614cb
   sha: sha256:f52e197b56ddfa20159a9f4967b87dc29a1987ea4a48acd159512761c4ae51e4
+nfs-debs/libk5crypto3_1.16-2ubuntu0.2_amd64.deb:
+  size: 85472
+  sha: sha256:d3cf88802e2a182ccd2214c454adda9fd895d35d73c9cda2c7ce53e5356c1927
 nfs-debs/libkrb5-3_1.15.1-2_amd64.deb:
   size: 276254
   object_id: e8d2e2aa-647a-45fd-53f1-b8d1199718b3
   sha: sha256:6613a940c56a785724e330645fd9ac9bf493b849cbb63c541b7a6ce1b426a99d
+nfs-debs/libkrb5-3_1.16-2ubuntu0.2_amd64.deb:
+  size: 278652
+  sha: sha256:43344f93c620dbaa9d3941cbad6900492273c609a728739dc68d816ca23a5df0
 nfs-debs/libkrb5support0_1.15.1-2_amd64.deb:
   size: 32158
   object_id: 721c58f2-7b41-4736-40f0-9fc36ea629c6
   sha: sha256:da7fd6c191485c6c64b484368a77f3cbbe2d0729f858045ea4182df09f77ba3a
+nfs-debs/libkrb5support0_1.16-2ubuntu0.2_amd64.deb:
+  size: 30824
+  sha: sha256:f09c0d595dc9124716bfdb250329335e18efb8840982dd1191d49c6f214f7dbf
+nfs-debs/libnfsidmap2_0.25-5.1_amd64.deb:
+  size: 27180
+  sha: sha256:ae6eaf479efa010b313b4e0cf18812e3ca6eb50b6392b7b52e854d6acafe866b
 nfs-debs/libnfsidmap2_0.25-5_amd64.deb:
   size: 32182
   object_id: d666fb5d-2e46-4bb1-6dba-b2e6368c6048
@@ -34,14 +51,23 @@ nfs-debs/libtirpc1_0.2.5-1.2+deb9u1_amd64.deb:
   size: 80634
   object_id: 671095cf-0251-4aab-63a8-ee86f9ec150d
   sha: sha256:2176796081db99169c578dbfc1d958e2170047be7bff9722350204953623be44
+nfs-debs/libtirpc1_0.2.5-1.2ubuntu0.1_amd64.deb:
+  size: 75708
+  sha: sha256:6e0e12526d37f786f7afec3e16a1b5687d97774fdc9596bc8f42291214df2a5d
 nfs-debs/nfs-common_1.3.4-2.1ubuntu4_amd64.deb:
   size: 205360
   object_id: 79011511-3a38-4446-4521-c05ff6ecfc63
   sha: sha256:d241607dacc6c922852e6d7ff7805912ba7cb1f8463e4e23033caac34481456c
+nfs-debs/nfs-common_1.3.4-2.1ubuntu5.3_amd64.deb:
+  size: 205520
+  sha: sha256:ecf4d9601d210d86d423457dd18a7d3af406ed34a273fb22ade431764fc66d67
 nfs-debs/rpcbind_0.2.3-0.6_amd64.deb:
   size: 45966
   object_id: 34ce9d16-81b5-4f83-6e52-14259e667a38
   sha: sha256:2338a1e969779c54d40ca9d53deb928afc721524e511dac38be76f1a61540f81
+nfs-debs/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb:
+  size: 42124
+  sha: sha256:ad1e5849523af0dba54a1f7e7f54d11f1a7a0131ce5de858a5ff37e61c27b35d
 openldap/openldap-2.4.44.tgz:
   size: 5658830
   object_id: daea5917-02c3-4fe5-4626-a8805979788d

--- a/jobs/nfsv3driver/templates/install.erb
+++ b/jobs/nfsv3driver/templates/install.erb
@@ -98,6 +98,21 @@ function main() {
   codename=$(lsb_release -c | cut -f 2 )
 
   case ${codename} in
+    "focal")
+      echo "Installing NFS packages"
+      (
+      flock -x 200
+      install_if_missing keyutils /var/vcap/packages/nfs-debs/keyutils_1.6-6ubuntu1_amd64.deb
+      install_if_missing libevent-2.1-6 /var/vcap/packages/nfs-debs/libevent-2.1-7_2.1.11-stable-1_amd64.deb
+      install_if_missing libnfsidmap2 /var/vcap/packages/nfs-debs/libnfsidmap2_0.25-5.1ubuntu1_amd64.deb
+      configure_if_present libk5crypto3
+      configure_if_present libkrb5-3
+      configure_if_present libgssapi-krb5-2
+      configure_if_present libtirpc1
+      install_or_upgrade rpcbind /var/vcap/packages/nfs-debs/rpcbind_1.2.5-8_amd64.deb
+      install_or_upgrade nfs-common /var/vcap/packages/nfs-debs/nfs-common_1.3.4-2.5ubuntu3.3_amd64.deb
+      ) 200>/var/vcap/data/dpkg.lock
+   ;;
    "bionic")
       echo "Installing NFS packages"
       (

--- a/jobs/nfsv3driver/templates/install.erb
+++ b/jobs/nfsv3driver/templates/install.erb
@@ -95,8 +95,27 @@ function prepend_rfc3339_datetime() {
 }
 
 function main() {
-  codename=$(lsb_release -c | grep xenial | awk '{print $2}')
-  if [ "$codename" == "xenial" ]; then
+  codename=$(lsb_release -c | cut -f 2 )
+
+  case ${codename} in
+   "bionic")
+      echo "Installing NFS packages"
+      (
+      flock -x 200
+      install_if_missing keyutils /var/vcap/packages/nfs-debs/keyutils_1.5.9-9.2ubuntu2_amd64.deb
+      install_if_missing libevent-2.1-6 /var/vcap/packages/nfs-debs/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb
+      install_if_missing libnfsidmap2 /var/vcap/packages/nfs-debs/libnfsidmap2_0.25-5.1_amd64.deb
+      install_or_upgrade libkrb5support0 /var/vcap/packages/nfs-debs/libkrb5support0_1.16-2ubuntu0.2_amd64.deb
+      install_or_upgrade libk5crypto3 /var/vcap/packages/nfs-debs/libk5crypto3_1.16-2ubuntu0.2_amd64.deb
+      install_or_upgrade libkrb5-3 /var/vcap/packages/nfs-debs/libkrb5-3_1.16-2ubuntu0.2_amd64.deb
+      configure_if_present libkrb5-3
+      install_or_upgrade libgssapi-krb5-2 /var/vcap/packages/nfs-debs/libgssapi-krb5-2_1.16-2ubuntu0.2_amd64.deb
+      install_or_upgrade libtirpc1 /var/vcap/packages/nfs-debs/libtirpc1_0.2.5-1.2ubuntu0.1_amd64.deb
+      install_or_upgrade rpcbind /var/vcap/packages/nfs-debs/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb
+      install_or_upgrade nfs-common /var/vcap/packages/nfs-debs/nfs-common_1.3.4-2.1ubuntu5.3_amd64.deb
+      ) 200>/var/vcap/data/dpkg.lock
+   ;;
+   "xenial")
       echo "Installing NFS packages"
       (
       flock -x 200
@@ -112,8 +131,8 @@ function main() {
       install_or_upgrade rpcbind /var/vcap/packages/nfs-debs/rpcbind_0.2.3-0.6_amd64.deb
       install_or_upgrade nfs-common /var/vcap/packages/nfs-debs/nfs-common_1.3.4-2.1ubuntu4_amd64.deb
       ) 200>/var/vcap/data/dpkg.lock
-  fi
-
+    ;;
+  esac
   echo "Copying client certs to data directory..."
   copy_client_certs_to_spec_dir
 

--- a/jobs/nfsv3driver/templates/install.erb
+++ b/jobs/nfsv3driver/templates/install.erb
@@ -105,12 +105,10 @@ function main() {
       install_if_missing keyutils /var/vcap/packages/nfs-debs/keyutils_1.5.9-9.2ubuntu2_amd64.deb
       install_if_missing libevent-2.1-6 /var/vcap/packages/nfs-debs/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb
       install_if_missing libnfsidmap2 /var/vcap/packages/nfs-debs/libnfsidmap2_0.25-5.1_amd64.deb
-      install_or_upgrade libkrb5support0 /var/vcap/packages/nfs-debs/libkrb5support0_1.16-2ubuntu0.2_amd64.deb
-      install_or_upgrade libk5crypto3 /var/vcap/packages/nfs-debs/libk5crypto3_1.16-2ubuntu0.2_amd64.deb
-      install_or_upgrade libkrb5-3 /var/vcap/packages/nfs-debs/libkrb5-3_1.16-2ubuntu0.2_amd64.deb
+      configure_if_present libk5crypto3
       configure_if_present libkrb5-3
-      install_or_upgrade libgssapi-krb5-2 /var/vcap/packages/nfs-debs/libgssapi-krb5-2_1.16-2ubuntu0.2_amd64.deb
-      install_or_upgrade libtirpc1 /var/vcap/packages/nfs-debs/libtirpc1_0.2.5-1.2ubuntu0.1_amd64.deb
+      configure_if_present libgssapi-krb5-2
+      configure_if_present libtirpc1
       install_or_upgrade rpcbind /var/vcap/packages/nfs-debs/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb
       install_or_upgrade nfs-common /var/vcap/packages/nfs-debs/nfs-common_1.3.4-2.1ubuntu5.3_amd64.deb
       ) 200>/var/vcap/data/dpkg.lock


### PR DESCRIPTION
Same as the other PR but this one also includes focal support

To get the focal blobs quickly:

```

wget http://security.ubuntu.com/ubuntu/pool/main/n/nfs-utils/nfs-common_1.3.4-2.5ubuntu3.3_amd64.deb \
     https://mirrors.edge.kernel.org/ubuntu/pool/main/libe/libevent/libevent-2.1-7_2.1.11-stable-1_amd64.deb \
     https://mirrors.edge.kernel.org/ubuntu/pool/main/k/keyutils/keyutils_1.6-6ubuntu1_amd64.deb \
     http://security.ubuntu.com/ubuntu/pool/main/r/rpcbind/rpcbind_1.2.5-8_amd64.deb \
     http://ubuntu.cs.utah.edu/ubuntu/pool/main/libn/libnfsidmap/libnfsidmap2_0.25-5.1ubuntu1_amd64.deb
```