### PR TITLE
jammy and bionic support for nfs-volume-services

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,43 +2,73 @@ berkeleydb/db-5.3.28.tar.gz:
   size: 35090431
   object_id: 3ad9234b-50b7-4f58-7d46-d3569f90d3d6
   sha: fa3f8a41ad5101f43d08bc0efb6241c9b6fc1ae9
-nfs-debs/keyutils_1.5.9-8ubuntu1_amd64.deb:
+nfs-debs/bionic/keyutils_1.5.9-9.2ubuntu2_amd64.deb:
+  size: 47896
+  sha: sha256:223a7160b6e2680d2b1f43abb067e0ccc08906bb2c5448ad4b3065f38309bbb5
+nfs-debs/bionic/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb:
+  size: 133328
+  sha: sha256:76bc94b3bb4356673c61dd2a4a7b06f40de21dab051aa4b31282aa9d7798b383
+nfs-debs/bionic/libnfsidmap2_0.25-5.1_amd64.deb:
+  size: 27180
+  sha: sha256:ae6eaf479efa010b313b4e0cf18812e3ca6eb50b6392b7b52e854d6acafe866b
+nfs-debs/bionic/nfs-common_1.3.4-2.1ubuntu5.5_amd64.deb:
+  size: 205604
+  sha: sha256:e5c2638a36827b3b7817cd8d4bf0bfa60c4e88f70d45e89a53b50cb98bad029e
+nfs-debs/bionic/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb:
+  size: 42124
+  sha: sha256:ad1e5849523af0dba54a1f7e7f54d11f1a7a0131ce5de858a5ff37e61c27b35d
+nfs-debs/jammy/keyutils_1.6.1-2ubuntu2_amd64.deb:
+  size: 47872
+  sha: sha256:9c92734d0e68453e6a47dc97fbc062d9af5036ccdd58eb7dc988272c7ba5bd62
+nfs-debs/jammy/libevent-2.1-7_2.1.12-stable-1build2_amd64.deb:
+  size: 148328
+  sha: sha256:191d4f23249ff9140bf0f7f307d1180d19be61865d4efd8faa6da702693d619c
+nfs-debs/jammy/libnfsidmap2_0.25-6build1_amd64.deb:
+  size: 27896
+  sha: sha256:a6d3c6b8db27c51d9aabcba372c626726648c6b60d7b94aa962a4465ec23ae5a
+nfs-debs/jammy/nfs-common_1.3.4-6ubuntu1_amd64.deb:
+  size: 219244
+  sha: sha256:291ebf25f5c811f51382f3d2dca4972a71ceedfd19ad72c56db716e7669a0598
+nfs-debs/jammy/rpcbind_1.2.6-2_amd64.deb:
+  size: 46506
+  sha: sha256:7e808f72e4278a24ac7851606d4a9c7f64a5bbdbd23f1cc73d3a0025af74eee7
+nfs-debs/xenial/keyutils_1.5.9-8ubuntu1_amd64.deb:
   size: 47054
   object_id: 79ec8102-01f0-4e62-7d5a-cac385c29c03
   sha: ec2e96e73feb5215605c9f0254cad05d9cc5688a
-nfs-debs/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb:
+nfs-debs/xenial/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb:
   size: 133328
   object_id: c1fc2753-6049-4791-4233-3bb002100204
   sha: sha256:76bc94b3bb4356673c61dd2a4a7b06f40de21dab051aa4b31282aa9d7798b383
-nfs-debs/libgssapi-krb5-2_1.15.1-2_amd64.deb:
+nfs-debs/xenial/libgssapi-krb5-2_1.15.1-2_amd64.deb:
   size: 120298
   object_id: 00800a67-3797-4f5a-6cf5-e2f8a4290d85
   sha: sha256:07affb4998cbd57d9d125349213cde5a191a5bb466f9085333c87d2a6b252648
-nfs-debs/libk5crypto3_1.15.1-2_amd64.deb:
+nfs-debs/xenial/libk5crypto3_1.15.1-2_amd64.deb:
   size: 84942
   object_id: 461520bc-8f33-4c19-7f13-fffa143614cb
   sha: sha256:f52e197b56ddfa20159a9f4967b87dc29a1987ea4a48acd159512761c4ae51e4
-nfs-debs/libkrb5-3_1.15.1-2_amd64.deb:
+nfs-debs/xenial/libkrb5-3_1.15.1-2_amd64.deb:
   size: 276254
   object_id: e8d2e2aa-647a-45fd-53f1-b8d1199718b3
   sha: sha256:6613a940c56a785724e330645fd9ac9bf493b849cbb63c541b7a6ce1b426a99d
-nfs-debs/libkrb5support0_1.15.1-2_amd64.deb:
+nfs-debs/xenial/libkrb5support0_1.15.1-2_amd64.deb:
   size: 32158
   object_id: 721c58f2-7b41-4736-40f0-9fc36ea629c6
   sha: sha256:da7fd6c191485c6c64b484368a77f3cbbe2d0729f858045ea4182df09f77ba3a
-nfs-debs/libnfsidmap2_0.25-5_amd64.deb:
+nfs-debs/xenial/libnfsidmap2_0.25-5_amd64.deb:
   size: 32182
   object_id: d666fb5d-2e46-4bb1-6dba-b2e6368c6048
   sha: f28b7370542daaf81cefb44d9057fa9b3fb43064
-nfs-debs/libtirpc1_0.2.5-1.2+deb9u1_amd64.deb:
+nfs-debs/xenial/libtirpc1_0.2.5-1.2+deb9u1_amd64.deb:
   size: 80634
   object_id: 671095cf-0251-4aab-63a8-ee86f9ec150d
   sha: sha256:2176796081db99169c578dbfc1d958e2170047be7bff9722350204953623be44
-nfs-debs/nfs-common_1.3.4-2.1ubuntu4_amd64.deb:
+nfs-debs/xenial/nfs-common_1.3.4-2.1ubuntu4_amd64.deb:
   size: 205360
   object_id: 79011511-3a38-4446-4521-c05ff6ecfc63
   sha: sha256:d241607dacc6c922852e6d7ff7805912ba7cb1f8463e4e23033caac34481456c
-nfs-debs/rpcbind_0.2.3-0.6_amd64.deb:
+nfs-debs/xenial/rpcbind_0.2.3-0.6_amd64.deb:
   size: 45966
   object_id: 34ce9d16-81b5-4f83-6e52-14259e667a38
   sha: sha256:2338a1e969779c54d40ca9d53deb928afc721524e511dac38be76f1a61540f81

--- a/jobs/nfsv3driver/templates/install.erb
+++ b/jobs/nfsv3driver/templates/install.erb
@@ -95,24 +95,54 @@ function prepend_rfc3339_datetime() {
 }
 
 function main() {
-  codename=$(lsb_release -c | grep xenial | awk '{print $2}')
-  if [ "$codename" == "xenial" ]; then
-      echo "Installing NFS packages"
-      (
-      flock -x 200
-      install_if_missing keyutils /var/vcap/packages/nfs-debs/keyutils_1.5.9-8ubuntu1_amd64.deb
-      install_if_missing libevent-2.1-6 /var/vcap/packages/nfs-debs/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb
-      install_if_missing libnfsidmap2 /var/vcap/packages/nfs-debs/libnfsidmap2_0.25-5_amd64.deb
-      install_or_upgrade libkrb5support0 /var/vcap/packages/nfs-debs/libkrb5support0_1.15.1-2_amd64.deb
-      install_or_upgrade libk5crypto3 /var/vcap/packages/nfs-debs/libk5crypto3_1.15.1-2_amd64.deb
-      install_or_upgrade libkrb5-3 /var/vcap/packages/nfs-debs/libkrb5-3_1.15.1-2_amd64.deb
-      configure_if_present libkrb5-3
-      install_or_upgrade libgssapi-krb5-2 /var/vcap/packages/nfs-debs/libgssapi-krb5-2_1.15.1-2_amd64.deb
-      install_or_upgrade libtirpc1 /var/vcap/packages/nfs-debs/libtirpc1_0.2.5-1.2+deb9u1_amd64.deb
-      install_or_upgrade rpcbind /var/vcap/packages/nfs-debs/rpcbind_0.2.3-0.6_amd64.deb
-      install_or_upgrade nfs-common /var/vcap/packages/nfs-debs/nfs-common_1.3.4-2.1ubuntu4_amd64.deb
-      ) 200>/var/vcap/data/dpkg.lock
-  fi
+  codename=$(lsb_release -c | cut -f 2 )
+  echo "Installing NFS packages ${codename}"
+  case ${codename} in
+  "jammy")
+    (
+    flock -x 200
+    install_if_missing keyutils /var/vcap/packages/nfs-debs/$codename/keyutils_1.6.1-2ubuntu2_amd64.deb
+    install_if_missing libevent-2.1-6 /var/vcap/packages/nfs-debs/$codename/libevent-2.1-7_2.1.12-stable-1build2_amd64.deb
+    install_if_missing libnfsidmap2 /var/vcap/packages/nfs-debs/$codename/libnfsidmap2_0.25-6build1_amd64.deb
+    configure_if_present libk5crypto3
+    configure_if_present libkrb5-3
+    configure_if_present libgssapi-krb5-2
+    configure_if_present libtirpc1
+    install_or_upgrade rpcbind /var/vcap/packages/nfs-debs/$codename/rpcbind_1.2.6-2_amd64.deb
+    install_or_upgrade nfs-common /var/vcap/packages/nfs-debs/$codename/nfs-common_1.3.4-6ubuntu1_amd64.deb
+    ) 200>/var/vcap/data/dpkg.lock
+  ;;
+  "bionic")
+    (
+    flock -x 200
+    install_if_missing keyutils /var/vcap/packages/nfs-debs/$codename/keyutils_1.5.9-9.2ubuntu2_amd64.deb
+    install_if_missing libevent-2.1-6 /var/vcap/packages/nfs-debs/$codename/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb
+    install_if_missing libnfsidmap2 /var/vcap/packages/nfs-debs/$codename/libnfsidmap2_0.25-5.1_amd64.deb
+    configure_if_present libk5crypto3
+    configure_if_present libkrb5-3
+    configure_if_present libgssapi-krb5-2
+    configure_if_present libtirpc1
+    install_or_upgrade rpcbind /var/vcap/packages/nfs-debs/$codename/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb
+    install_or_upgrade nfs-common /var/vcap/packages/nfs-debs/$codename/nfs-common_1.3.4-2.1ubuntu5.5_amd64.deb
+    ) 200>/var/vcap/data/dpkg.lock
+  ;;
+  "xenial")
+    (
+    flock -x 200
+    install_if_missing keyutils /var/vcap/packages/nfs-debs/$codename/keyutils_1.5.9-8ubuntu1_amd64.deb
+    install_if_missing libevent-2.1-6 /var/vcap/packages/nfs-debs/$codename/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb
+    install_if_missing libnfsidmap2 /var/vcap/packages/nfs-debs/$codename/libnfsidmap2_0.25-5_amd64.deb
+    install_or_upgrade libkrb5support0 /var/vcap/packages/nfs-debs/$codename/libkrb5support0_1.15.1-2_amd64.deb
+    install_or_upgrade libk5crypto3 /var/vcap/packages/nfs-debs/$codename/libk5crypto3_1.15.1-2_amd64.deb
+    install_or_upgrade libkrb5-3 /var/vcap/packages/nfs-debs/$codename/libkrb5-3_1.15.1-2_amd64.deb
+    configure_if_present libkrb5-3
+    install_or_upgrade libgssapi-krb5-2 /var/vcap/packages/nfs-debs/$codename/libgssapi-krb5-2_1.15.1-2_amd64.deb
+    install_or_upgrade libtirpc1 /var/vcap/packages/nfs-debs/$codename/libtirpc1_0.2.5-1.2+deb9u1_amd64.deb
+    install_or_upgrade rpcbind /var/vcap/packages/nfs-debs/$codename/rpcbind_0.2.3-0.6_amd64.deb
+    install_or_upgrade nfs-common /var/vcap/packages/nfs-debs/$codename/nfs-common_1.3.4-2.1ubuntu4_amd64.deb
+    ) 200>/var/vcap/data/dpkg.lock
+  ;;
+  esac
 
   echo "Copying client certs to data directory..."
   copy_client_certs_to_spec_dir

--- a/packages/nfs-debs/packaging
+++ b/packages/nfs-debs/packaging
@@ -2,4 +2,4 @@
 
 set -e
 
-cp -a ${BOSH_COMPILE_TARGET}/nfs-debs/*.deb ${BOSH_INSTALL_TARGET}/
+cp -ra ${BOSH_COMPILE_TARGET}/nfs-debs/* ${BOSH_INSTALL_TARGET}/


### PR DESCRIPTION
Since my last two still aren't accepted, I will try this one. It adds support for bionic and jammy (which I guess is what people plan to use?) while maintaining "support" for xenial.

I think xenial support should be dropped since we can't obtain new packages.

Here is a script to obtain the blobs I used so you can create your own release from this. 
```
mkdir -p bionic
wget -O bionic/keyutils_1.5.9-9.2ubuntu2_amd64.deb http://mirrors.kernel.org/ubuntu/pool/main/k/keyutils/keyutils_1.5.9-9.2ubuntu2_amd64.deb
wget -O bionic/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb http://mirrors.kernel.org/ubuntu/pool/main/libe/libevent/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb
wget -O bionic/libnfsidmap2_0.25-5.1_amd64.deb http://mirrors.kernel.org/ubuntu/pool/main/libn/libnfsidmap/libnfsidmap2_0.25-5.1_amd64.deb
wget -O bionic/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb http://mirrors.kernel.org/ubuntu/pool/main/r/rpcbind/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb
wget -O bionic/nfs-common_1.3.4-2.1ubuntu5.5_amd64.deb http://mirrors.kernel.org/ubuntu/pool/main/n/nfs-utils/nfs-common_1.3.4-2.1ubuntu5.5_amd64.deb
mkdir -p jammy
wget -O jammy/keyutils_1.6.1-2ubuntu2_amd64.deb http://mirrors.kernel.org/ubuntu/pool/main/k/keyutils/keyutils_1.6.1-2ubuntu2_amd64.deb
wget -O jammy/libevent-2.1-7_2.1.12-stable-1build2_amd64.deb http://mirrors.kernel.org/ubuntu/pool/main/libe/libevent/libevent-2.1-7_2.1.12-stable-1build2_amd64.deb
wget -O jammy/libnfsidmap2_0.25-6build1_amd64.deb http://mirrors.kernel.org/ubuntu/pool/main/libn/libnfsidmap/libnfsidmap2_0.25-6build1_amd64.deb
wget -O jammy/rpcbind_1.2.6-2_amd64.deb http://mirrors.kernel.org/ubuntu/pool/main/r/rpcbind/rpcbind_1.2.6-2_amd64.deb
wget -O jammy/nfs-common_1.3.4-6ubuntu1_amd64.deb http://mirrors.kernel.org/ubuntu/pool/main/n/nfs-utils/nfs-common_1.3.4-6ubuntu1_amd64.deb
```
