### PR TITLE
Upload blobs for jammy and bionic

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -4,34 +4,44 @@ berkeleydb/db-5.3.28.tar.gz:
   sha: fa3f8a41ad5101f43d08bc0efb6241c9b6fc1ae9
 nfs-debs/bionic/keyutils_1.5.9-9.2ubuntu2_amd64.deb:
   size: 47896
+  object_id: b1c4adab-3acd-45f9-5558-d893ab0a2937
   sha: sha256:223a7160b6e2680d2b1f43abb067e0ccc08906bb2c5448ad4b3065f38309bbb5
 nfs-debs/bionic/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb:
   size: 133328
+  object_id: c7db62da-06d2-4ee8-6508-9c3daf9883db
   sha: sha256:76bc94b3bb4356673c61dd2a4a7b06f40de21dab051aa4b31282aa9d7798b383
 nfs-debs/bionic/libnfsidmap2_0.25-5.1_amd64.deb:
   size: 27180
+  object_id: ac0a86ba-ef76-4d1c-6e61-2e2dfcfd511c
   sha: sha256:ae6eaf479efa010b313b4e0cf18812e3ca6eb50b6392b7b52e854d6acafe866b
 nfs-debs/bionic/nfs-common_1.3.4-2.1ubuntu5.5_amd64.deb:
   size: 205604
+  object_id: 8f569ad0-56c5-4bf2-4b8a-8ad9c077f013
   sha: sha256:e5c2638a36827b3b7817cd8d4bf0bfa60c4e88f70d45e89a53b50cb98bad029e
 nfs-debs/bionic/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb:
   size: 42124
+  object_id: fa159f54-edd0-4e78-7393-cda37ca9c7e0
   sha: sha256:ad1e5849523af0dba54a1f7e7f54d11f1a7a0131ce5de858a5ff37e61c27b35d
-nfs-debs/jammy/keyutils_1.6.1-2ubuntu2_amd64.deb:
-  size: 47872
-  sha: sha256:9c92734d0e68453e6a47dc97fbc062d9af5036ccdd58eb7dc988272c7ba5bd62
-nfs-debs/jammy/libevent-2.1-7_2.1.12-stable-1build2_amd64.deb:
-  size: 148328
-  sha: sha256:191d4f23249ff9140bf0f7f307d1180d19be61865d4efd8faa6da702693d619c
+nfs-debs/jammy/keyutils_1.6.1-2ubuntu3_amd64.deb:
+  size: 50410
+  object_id: 6a525e94-1a19-4da7-5b9c-8f90509b6681
+  sha: sha256:39da334791f57894fa13f680470e048383074b6c02aeb58e206033c5a3d0e925
+nfs-debs/jammy/libevent-2.1-7_2.1.12-stable-1build3_amd64.deb:
+  size: 148238
+  object_id: 2dea972e-5825-485d-5287-67d20fe2d7cb
+  sha: sha256:e13aac87e4143293cf1d3cb82a2458fbeacc234d0db0667fd5567bdcd6da15fe
 nfs-debs/jammy/libnfsidmap2_0.25-6build1_amd64.deb:
   size: 27896
+  object_id: 941ca15d-7c40-4533-67a2-a23af0978300
   sha: sha256:a6d3c6b8db27c51d9aabcba372c626726648c6b60d7b94aa962a4465ec23ae5a
 nfs-debs/jammy/nfs-common_1.3.4-6ubuntu1_amd64.deb:
   size: 219244
+  object_id: f767427a-61b5-4686-5352-d8c91acceba3
   sha: sha256:291ebf25f5c811f51382f3d2dca4972a71ceedfd19ad72c56db716e7669a0598
-nfs-debs/jammy/rpcbind_1.2.6-2_amd64.deb:
-  size: 46506
-  sha: sha256:7e808f72e4278a24ac7851606d4a9c7f64a5bbdbd23f1cc73d3a0025af74eee7
+nfs-debs/jammy/rpcbind_1.2.6-2build1_amd64.deb:
+  size: 46608
+  object_id: 6b175861-ab18-4247-6e08-7c69c25f0efe
+  sha: sha256:40f5113c7d8711c2ac8ad50ffee7fa0890731e22da0a99bee3fbc6cdd1f451ac
 nfs-debs/xenial/keyutils_1.5.9-8ubuntu1_amd64.deb:
   size: 47054
   object_id: 79ec8102-01f0-4e62-7d5a-cac385c29c03

--- a/jobs/nfsv3driver/templates/install.erb
+++ b/jobs/nfsv3driver/templates/install.erb
@@ -101,14 +101,14 @@ function main() {
   "jammy")
     (
     flock -x 200
-    install_if_missing keyutils /var/vcap/packages/nfs-debs/$codename/keyutils_1.6.1-2ubuntu2_amd64.deb
-    install_if_missing libevent-2.1-6 /var/vcap/packages/nfs-debs/$codename/libevent-2.1-7_2.1.12-stable-1build2_amd64.deb
+    install_if_missing keyutils /var/vcap/packages/nfs-debs/$codename/keyutils_1.6.1-2ubuntu3_amd64.deb
+    install_if_missing libevent-2.1-6 /var/vcap/packages/nfs-debs/$codename/libevent-2.1-7_2.1.12-stable-1build3_amd64.deb
     install_if_missing libnfsidmap2 /var/vcap/packages/nfs-debs/$codename/libnfsidmap2_0.25-6build1_amd64.deb
     configure_if_present libk5crypto3
     configure_if_present libkrb5-3
     configure_if_present libgssapi-krb5-2
     configure_if_present libtirpc1
-    install_or_upgrade rpcbind /var/vcap/packages/nfs-debs/$codename/rpcbind_1.2.6-2_amd64.deb
+    install_or_upgrade rpcbind /var/vcap/packages/nfs-debs/$codename/rpcbind_1.2.6-2build1_amd64.deb
     install_or_upgrade nfs-common /var/vcap/packages/nfs-debs/$codename/nfs-common_1.3.4-6ubuntu1_amd64.deb
     ) 200>/var/vcap/data/dpkg.lock
   ;;


### PR DESCRIPTION
[#181695451]

Some packages were no longer available in kernel.org so alternate
ones were added.
Script `install.erb` was modified to adapt to new packages added.

Co-authored-by: Gareth Smith <sgareth@vmware.com>
Co-authored-by: Diego Lemos <dlemos@vmware.com>
Co-authored-by: Iain Findlay <fiain@vmware.com>