### PR TITLE
Add support for CF CLI v8 to errands

### DIFF
--- a/jobs/nfsbroker-bbr-lock/templates/post-restore-unlock.sh.erb
+++ b/jobs/nfsbroker-bbr-lock/templates/post-restore-unlock.sh.erb
@@ -4,6 +4,7 @@ set -x
 
 PATH="/var/vcap/packages/cf-cli-6-linux/bin:${PATH}"
 PATH="/var/vcap/packages/cf-cli-7-linux/bin:${PATH}"
+PATH="/var/vcap/packages/cf-cli-8-linux/bin:${PATH}"
 
 API_ENDPOINT=https://api.<%= link('nfsbrokerpush').p('nfsbrokerpush.domain') %>
 ORG=<%= link('nfsbrokerpush').p('nfsbrokerpush.organization') %>

--- a/jobs/nfsbrokerpush/templates/deploy.sh.erb
+++ b/jobs/nfsbrokerpush/templates/deploy.sh.erb
@@ -2,6 +2,7 @@
 
 export PATH="/var/vcap/packages/cf-cli-6-linux/bin:$PATH"
 export PATH="/var/vcap/packages/cf-cli-7-linux/bin:$PATH"
+export PATH="/var/vcap/packages/cf-cli-8-linux/bin:${PATH}"
 export CF_HOME=/var/vcap/data/nfsbrokerpush_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 6 | head -n 1)/
 export CF_DIAL_TIMEOUT=<%= p('nfsbrokerpush.cf.dial_timeout') %>
 
@@ -48,10 +49,10 @@ function authenticate_and_target() {
 function create_credhub_security_group() {
   cf create-security-group credhub_open /var/vcap/jobs/nfsbrokerpush/credhub.json
   cf update-security-group credhub_open /var/vcap/jobs/nfsbrokerpush/credhub.json
-  if [[ -d "/var/vcap/packages/cf-cli-7-linux" ]]; then
-    cf bind-security-group credhub_open $ORG --space $SPACE
-  else
+  if [[ -d "/var/vcap/packages/cf-cli-6-linux" ]]; then
     cf bind-security-group credhub_open $ORG $SPACE
+  else
+    cf bind-security-group credhub_open $ORG --space $SPACE
   fi
 }
 


### PR DESCRIPTION
This PR updates the `nfsbrokerpush/deploy` and `nfsbroker-bbr-lock/post-restore-unlock` scripts so that they now work with v6, v7 or v8 of the CF CLI.

Resolves #158