### PR TITLE
Stop autobumping v2.3 /src/bosh_release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,11 +27,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "gomod"
-    target-branch: "v2.3"
-    directory: "/src/bosh_release/"
-    schedule:
-      interval: "daily"
 
 ####################################
 # Settings for branch v5.0 used in:


### PR DESCRIPTION
Folder /src/bosh_release doesn't contain a go.mod file in branch v2.3
Dependabot can't autobump go dependencies without a go.mod file.
Stop trying to autobump dependencies in this folder for branch v2.3.