### PR TITLE
[ci] Force use of iptables instead of nftables

### DIFF
--- a/scripts/run-bosh-release-tests-in-docker-env.sh
+++ b/scripts/run-bosh-release-tests-in-docker-env.sh
@@ -5,6 +5,9 @@ if [[ -n "$DEV" ]]; then
     COMMAND_TO_RUN='bash'
 fi
 
+update-alternatives --set iptables /usr/sbin/iptables-legacy
+update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
 export DOCKER_STORAGE_OPTIONS='--storage-opt dm.basesize=100G'
 . start-bosh
 


### PR DESCRIPTION
Docker seems to expect iptables to be present. Ubuntu/Debian seems to be
using nftables (since Jammy)?

[#182790207]