### PR TITLE
Rename golang package to specify only MAJOR version

### DIFF
--- a/.final_builds/packages/golang-1.13-linux/index.yml
+++ b/.final_builds/packages/golang-1.13-linux/index.yml
@@ -1,6 +1,0 @@
-builds:
-  20234d0cb26adec9565b926f59fa4f7a2ea9e4f230af800fa9a36c8b5f2a8eaa:
-    version: 20234d0cb26adec9565b926f59fa4f7a2ea9e4f230af800fa9a36c8b5f2a8eaa
-    blobstore_id: 9c22d93d-06f9-43be-65f9-488bd425bb27
-    sha1: sha256:660936725d973c27d36bd021cee3905616eb68583ba8199f83b8c0dd4fe259a2
-format-version: "2"

--- a/dockerfiles/nfs-integration-tests/Dockerfile
+++ b/dockerfiles/nfs-integration-tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM relintdockerhubpushbot/cf-deployment-concourse-tasks as golang_version
 RUN git clone --recurse-submodules https://github.com/cloudfoundry/nfs-volume-release
 RUN cd nfs-volume-release && bosh create-release --tarball /tmp/release.tgz
-RUN version=$(cat /tmp/release.tgz | tar -Oxz packages/golang-1.13-linux.tgz | tar z --list | grep -ohE "go[0-9]\.[0-9]{1,2}\.[0-9]{1,2}") && echo $version > /tmp/golang_version
+RUN version=$(cat /tmp/release.tgz | tar -Oxz packages/golang-1-linux.tgz | tar z --list | grep -ohE "go[0-9]\.[0-9]{1,2}\.[0-9]{1,2}") && echo $version > /tmp/golang_version
 RUN ginkgo_version=$(cd nfs-volume-release/src/bosh_release/ && go list -f "{{.Version}}" -m github.com/onsi/ginkgo > /tmp/ginkgo_version)
 
 FROM apnar/nfs-ganesha@sha256:e06f4f94e41ee7f490ce5f82fb39f44b09e75900b4444828ee71a9d59b5321e0

--- a/dockerfiles/nfs-unit-tests/Dockerfile
+++ b/dockerfiles/nfs-unit-tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM relintdockerhubpushbot/cf-deployment-concourse-tasks as golang_version
 RUN git clone --recurse-submodules https://github.com/cloudfoundry/nfs-volume-release
 RUN cd nfs-volume-release && bosh create-release --tarball /tmp/release.tgz
-RUN version=$(cat /tmp/release.tgz | tar -Oxz packages/golang-1.13-linux.tgz | tar z --list | grep -ohE "go[0-9]\.[0-9]{1,2}\.[0-9]{1,2}") && echo $version > /tmp/golang_version
+RUN version=$(cat /tmp/release.tgz | tar -Oxz packages/golang-1-linux.tgz | tar z --list | grep -ohE "go[0-9]\.[0-9]{1,2}\.[0-9]{1,2}") && echo $version > /tmp/golang_version
 RUN ginkgo_version=$(cd nfs-volume-release/src/bosh_release/ && go list -f "{{.Version}}" -m github.com/onsi/ginkgo > /tmp/ginkgo_version)
 
 FROM ubuntu

--- a/packages/golang-1.13-linux/spec.lock
+++ b/packages/golang-1.13-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.13-linux
-fingerprint: 20234d0cb26adec9565b926f59fa4f7a2ea9e4f230af800fa9a36c8b5f2a8eaa

--- a/packages/nfsbroker/packaging
+++ b/packages/nfsbroker/packaging
@@ -1,6 +1,6 @@
 set -e
 
-source /var/vcap/packages/golang-1.13-linux/bosh/compile.env
+source /var/vcap/packages/golang-1-linux/bosh/compile.env
 
 mkdir ../src && cp -a * ../src/ && mv ../src ./src
 mkdir $BOSH_INSTALL_TARGET/bin

--- a/packages/nfsbroker/spec
+++ b/packages/nfsbroker/spec
@@ -2,7 +2,7 @@
 name: nfsbroker
 
 dependencies:
-- golang-1.13-linux
+- golang-1-linux
 
 files:
   - code.cloudfoundry.org/nfsbroker/**

--- a/packages/nfsv3driver/packaging
+++ b/packages/nfsv3driver/packaging
@@ -1,6 +1,6 @@
 set -e
 
-source /var/vcap/packages/golang-1.13-linux/bosh/compile.env
+source /var/vcap/packages/golang-1-linux/bosh/compile.env
 
 mkdir ../src && cp -a * ../src/ && mv ../src ./src
 mkdir $BOSH_INSTALL_TARGET/bin

--- a/packages/nfsv3driver/spec
+++ b/packages/nfsv3driver/spec
@@ -2,7 +2,7 @@
 name: nfsv3driver
 
 dependencies:
-- golang-1.13-linux
+- golang-1-linux
 
 files:
   - code.cloudfoundry.org/nfsv3driver/**


### PR DESCRIPTION
[#183025303]

As commented in PR #198 this has several benefits and aligns with some
practices from the golang-release we depend upon for vendoring go.