### PR TITLE
Replace `go get` with `go install`

### DIFF
--- a/dockerfiles/nfs-integration-tests/Dockerfile
+++ b/dockerfiles/nfs-integration-tests/Dockerfile
@@ -27,7 +27,7 @@ ENV GOPATH /go
 ENV GOROOT=/usr/local/go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-RUN GO111MODULE=on go get github.com/onsi/ginkgo/ginkgo@$(cat /tmp/ginkgo_version)
+RUN GO111MODULE=on go install github.com/onsi/ginkgo/ginkgo@$(cat /tmp/ginkgo_version)
 
 
 RUN sed -i 's/VFS/MEM/' /start.sh

--- a/dockerfiles/nfs-unit-tests/Dockerfile
+++ b/dockerfiles/nfs-unit-tests/Dockerfile
@@ -19,4 +19,4 @@ ENV GOPATH /go
 ENV GOROOT=/usr/local/go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-RUN GO111MODULE=on go get github.com/onsi/ginkgo/ginkgo@$(cat /tmp/ginkgo_version)
+RUN GO111MODULE=on go install github.com/onsi/ginkgo/ginkgo@$(cat /tmp/ginkgo_version)


### PR DESCRIPTION
[#183154297]

Newest versions of go disallow the usage
of `go get` to install packages globally
and requires you to migrate to `go install`