### PR TITLE
Use the newer golang package, not the older one

### DIFF
--- a/dockerfiles/nfs-broker-tests/Dockerfile
+++ b/dockerfiles/nfs-broker-tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM relintdockerhubpushbot/cf-deployment-concourse-tasks as golang_version
 RUN git clone --recurse-submodules https://github.com/cloudfoundry/nfs-volume-release
 RUN cd nfs-volume-release && bosh create-release --tarball /tmp/release.tgz
-RUN version=$(cat /tmp/release.tgz | tar -Oxz packages/golang-1.13-linux.tgz | tar z --list | grep -ohE "go[0-9]\.[0-9]{1,2}\.[0-9]{1,2}") && echo $version > /tmp/golang_version
+RUN version=$(cat /tmp/release.tgz | tar -Oxz packages/golang-1-linux.tgz | tar z --list | grep -ohE "go[0-9]\.[0-9]{1,2}\.[0-9]{1,2}") && echo $version > /tmp/golang_version
 
 FROM openjdk:8 as builder
 RUN git clone https://github.com/cloudfoundry-incubator/credhub

--- a/dockerfiles/nfs-integration-tests/Dockerfile
+++ b/dockerfiles/nfs-integration-tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM relintdockerhubpushbot/cf-deployment-concourse-tasks as golang_version
 RUN git clone --recurse-submodules https://github.com/cloudfoundry/nfs-volume-release
 RUN cd nfs-volume-release && bosh create-release --tarball /tmp/release.tgz
-RUN version=$(cat /tmp/release.tgz | tar -Oxz packages/golang-1.13-linux.tgz | tar z --list | grep -ohE "go[0-9]\.[0-9]{1,2}\.[0-9]{1,2}") && echo $version > /tmp/golang_version
+RUN version=$(cat /tmp/release.tgz | tar -Oxz packages/golang-1-linux.tgz | tar z --list | grep -ohE "go[0-9]\.[0-9]{1,2}\.[0-9]{1,2}") && echo $version > /tmp/golang_version
 
 FROM apnar/nfs-ganesha
 

--- a/dockerfiles/nfs-unit-tests/Dockerfile
+++ b/dockerfiles/nfs-unit-tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM relintdockerhubpushbot/cf-deployment-concourse-tasks as golang_version
 RUN git clone --recurse-submodules https://github.com/cloudfoundry/nfs-volume-release
 RUN cd nfs-volume-release && bosh create-release --tarball /tmp/release.tgz
-RUN version=$(cat /tmp/release.tgz | tar -Oxz packages/golang-1.13-linux.tgz | tar z --list | grep -ohE "go[0-9]\.[0-9]{1,2}\.[0-9]{1,2}") && echo $version > /tmp/golang_version
+RUN version=$(cat /tmp/release.tgz | tar -Oxz packages/golang-1-linux.tgz | tar z --list | grep -ohE "go[0-9]\.[0-9]{1,2}\.[0-9]{1,2}") && echo $version > /tmp/golang_version
 
 FROM ubuntu
 

--- a/packages/golang-1.13-linux/spec.lock
+++ b/packages/golang-1.13-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.13-linux
-fingerprint: 20234d0cb26adec9565b926f59fa4f7a2ea9e4f230af800fa9a36c8b5f2a8eaa

--- a/packages/migrate_mysql_to_credhub/packaging
+++ b/packages/migrate_mysql_to_credhub/packaging
@@ -1,6 +1,6 @@
 set -e
 
-source /var/vcap/packages/golang-1.13-linux/bosh/compile.env
+source /var/vcap/packages/golang-1-linux/bosh/compile.env
 
 mkdir ../src && cp -a * ../src/ && mv ../src ./src
 mkdir $BOSH_INSTALL_TARGET/bin

--- a/packages/migrate_mysql_to_credhub/spec
+++ b/packages/migrate_mysql_to_credhub/spec
@@ -2,7 +2,7 @@
 name: migrate_mysql_to_credhub
 
 dependencies:
-- golang-1.13-linux
+- golang-1-linux
 
 files:
   - code.cloudfoundry.org/migrate_mysql_to_credhub/**

--- a/packages/nfsbroker/packaging
+++ b/packages/nfsbroker/packaging
@@ -1,6 +1,6 @@
 set -e
 
-source /var/vcap/packages/golang-1.13-linux/bosh/compile.env
+source /var/vcap/packages/golang-1-linux/bosh/compile.env
 
 mkdir ../src && cp -a * ../src/ && mv ../src ./src
 mkdir $BOSH_INSTALL_TARGET/bin

--- a/packages/nfsbroker/spec
+++ b/packages/nfsbroker/spec
@@ -2,7 +2,7 @@
 name: nfsbroker
 
 dependencies:
-- golang-1.13-linux
+- golang-1-linux
 
 files:
   - code.cloudfoundry.org/nfsbroker/**

--- a/packages/nfsv3driver/packaging
+++ b/packages/nfsv3driver/packaging
@@ -1,6 +1,6 @@
 set -e
 
-source /var/vcap/packages/golang-1.13-linux/bosh/compile.env
+source /var/vcap/packages/golang-1-linux/bosh/compile.env
 
 mkdir ../src && cp -a * ../src/ && mv ../src ./src
 mkdir $BOSH_INSTALL_TARGET/bin

--- a/packages/nfsv3driver/spec
+++ b/packages/nfsv3driver/spec
@@ -2,7 +2,7 @@
 name: nfsv3driver
 
 dependencies:
-- golang-1.13-linux
+- golang-1-linux
 
 files:
   - code.cloudfoundry.org/nfsv3driver/**


### PR DESCRIPTION
Previously we were using two different golang packages in this release:
- `golang-1-linux`, which we kept autobumping for the latest CVEs
- `golang-1.13-linux` which we actually used in other packages

I think that the 1.13 package is a remnant of a partly-completed upgrade. I think we should be using the newer `golang-1-linux` package everywhere, and should delete the older 1.13 package. That is what this commit does.

This will hopefully address [issue #183576985](https://www.pivotaltracker.com/story/show/183576985)