### PR TITLE
Include openldap 2.4.44 blob in release to use it in Xenial

### DIFF
--- a/.github/dockerfiles/dockerize-release/Dockerfile
+++ b/.github/dockerfiles/dockerize-release/Dockerfile
@@ -59,6 +59,7 @@ nfs-debs                              \
 nfsbroker                             \
 nfsv3driver                           \
 berkeleydb                            \
+openldap-2.4.44                       \
 openldap-2.5.13"
 
 WORKDIR /release/packages

--- a/.github/workflows/compilation-tests.yml
+++ b/.github/workflows/compilation-tests.yml
@@ -2,7 +2,6 @@ on:
   pull_request:
     branches:
       - master
-      - v5.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,13 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        base-branch: 
-        - ${{ github.base_ref }}
         stemcell-name: [ubuntu-bionic, ubuntu-jammy, ubuntu-xenial]
-        exclude:
-        # Support for Xenial Stemcell is available in branch v5.0
-        - base-branch: master
-          stemcell-name: ubuntu-xenial
 
     steps:
       - uses: actions/checkout@v3

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -82,6 +82,10 @@ nfs-debs/xenial/rpcbind_0.2.3-0.6_amd64.deb:
   size: 45966
   object_id: 34ce9d16-81b5-4f83-6e52-14259e667a38
   sha: sha256:2338a1e969779c54d40ca9d53deb928afc721524e511dac38be76f1a61540f81
+openldap/openldap-2.4.44.tgz:
+  size: 5658830
+  object_id: daea5917-02c3-4fe5-4626-a8805979788d
+  sha: 016a738d050a68d388602a74b5e991035cdba149
 openldap/openldap-2.5.13.tgz:
   size: 6454072
   object_id: 92766a2b-d302-4a56-574e-abdd76726f39

--- a/jobs/nfstestldapserver/spec
+++ b/jobs/nfstestldapserver/spec
@@ -1,6 +1,7 @@
 ---
 name: nfstestldapserver
 packages:
+- openldap-2.4.44
 - openldap-2.5.13
 templates:
   bin/ctl: bin/ctl

--- a/jobs/nfstestldapserver/templates/bin/ctl
+++ b/jobs/nfstestldapserver/templates/bin/ctl
@@ -8,8 +8,13 @@ source /var/vcap/jobs/nfstestldapserver/helpers/ctl_setup.sh 'nfstestldapserver'
 
 export PORT=${PORT:-5000}
 export LANG=en_US.UTF-8
-
-export OPENLDAP=/var/vcap/packages/openldap-2.5.13
+codename=$(lsb_release -c | cut -f 2 )
+if [[ "${codename}" == "xenial" ]];
+then
+  export OPENLDAP=/var/vcap/packages/openldap-2.4.44
+else
+  export OPENLDAP=/var/vcap/packages/openldap-2.5.13
+fi
 export PATH=${OPENLDAP}/libexec:${OPENLDAP}/sbin:$PATH
 
 case $1 in

--- a/jobs/nfstestldapserver/templates/post-start.erb
+++ b/jobs/nfstestldapserver/templates/post-start.erb
@@ -1,10 +1,21 @@
 #!/bin/bash
 
-export OPENLDAP=/var/vcap/packages/openldap-2.5.13
-export PATH=${OPENLDAP}/libexec:${OPENLDAP}/sbin:${OPENLDAP}/bin:$PATH
+codename=$(lsb_release -c | cut -f 2 )
+if [[ "${codename}" == "xenial" ]];
+then
+  export OPENLDAP=/var/vcap/packages/openldap-2.4.44
+  export PATH=${OPENLDAP}/libexec:${OPENLDAP}/sbin:${OPENLDAP}/bin:$PATH
 
-pushd /var/vcap/jobs/nfstestldapserver/config/
-ldapadd -x -w secret -H ldap://127.0.0.1:389 -D "cn=admin,dc=domain,dc=com" -f addou.ldif
-ldapadd -x -w secret -H ldap://127.0.0.1:389 -D "cn=admin,dc=domain,dc=com" -f adduser.ldif
+  pushd /var/vcap/jobs/nfstestldapserver/config/
+  ldapadd -x -w secret -h 127.0.0.1 -p 389 -D "cn=admin,dc=domain,dc=com" -f addou.ldif
+  ldapadd -x -w secret -h 127.0.0.1 -p 389 -D "cn=admin,dc=domain,dc=com" -f adduser.ldif
+else
+  export OPENLDAP=/var/vcap/packages/openldap-2.5.13
+  export PATH=${OPENLDAP}/libexec:${OPENLDAP}/sbin:${OPENLDAP}/bin:$PATH
+
+  pushd /var/vcap/jobs/nfstestldapserver/config/
+  ldapadd -x -w secret -H ldap://127.0.0.1:389 -D "cn=admin,dc=domain,dc=com" -f addou.ldif
+  ldapadd -x -w secret -H ldap://127.0.0.1:389 -D "cn=admin,dc=domain,dc=com" -f adduser.ldif
+fi
 
 exit 0

--- a/jobs/nfstestldapserver/templates/slapd.ldif.erb
+++ b/jobs/nfstestldapserver/templates/slapd.ldif.erb
@@ -34,7 +34,11 @@ olcPidFile: /var/vcap/sys/run/nfstestldapserver/nfstestldapserver.pid
 #dn: cn=module,cn=config
 #objectClass: olcModuleList
 #cn: module
+#<% if system("bash -c 'lsb_release -c | cut -f 2'") == "xenial" %>
+#olcModulepath:	/var/vcap/packages/openldap-2-4-44/libexec/openldap
+#<% else %>
 #olcModulepath:	/var/vcap/packages/openldap-2.5.13/libexec/openldap
+#<% end %>
 #olcModuleload:	back_bdb.la
 #olcModuleload:	back_hdb.la
 #olcModuleload:	back_ldap.la
@@ -47,9 +51,15 @@ objectClass: olcSchemaConfig
 cn: schema
 
 include: file:///var/vcap/jobs/nfstestldapserver/config/core.ldif
+#<% if system("bash -c 'lsb_release -c | cut -f 2'") == "xenial" %>
+include: file:///var/vcap/packages/openldap-2.4.44/etc/openldap/schema/cosine.ldif
+include: file:///var/vcap/packages/openldap-2.4.44/etc/openldap/schema/nis.ldif
+include: file:///var/vcap/packages/openldap-2.4.44/etc/openldap/schema/inetorgperson.ldif
+#<% else %>
 include: file:///var/vcap/packages/openldap-2.5.13/etc/openldap/schema/cosine.ldif
 include: file:///var/vcap/packages/openldap-2.5.13/etc/openldap/schema/nis.ldif
 include: file:///var/vcap/packages/openldap-2.5.13/etc/openldap/schema/inetorgperson.ldif
+#<% end %>
 
 # Frontend settings
 #

--- a/packages/openldap-2.4.44/packaging
+++ b/packages/openldap-2.4.44/packaging
@@ -2,7 +2,7 @@ set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
 codename=$(lsb_release -c | cut -f 2 )
-if [[ "${codename}" == "xenial" ]];
+if [[ "${codename}" != "xenial" ]];
 then
   exit 0
 fi
@@ -16,8 +16,8 @@ export HOME=/var/vcap
 export BDB_PATH=/var/vcap/packages/berkeleydb
 
 cd $BOSH_COMPILE_TARGET
-tar -xzvf openldap/openldap-2.5.13.tgz
-cd openldap-2.5.13
+tar -xzvf openldap/openldap-2.4.44.tgz
+cd openldap-2.4.44
 
 export CPPFLAGS="-I ${BDB_PATH}/include"
 export LD_LIBRARY_PATH="${BDB_PATH}/lib"

--- a/packages/openldap-2.4.44/spec
+++ b/packages/openldap-2.4.44/spec
@@ -1,0 +1,5 @@
+---
+ name: openldap-2.4.44
+ dependencies: [berkeleydb]
+ files:
+ - openldap/openldap-2.4.44.tgz


### PR DESCRIPTION
[#183555103]

This change includes an older version of openldap in the release. At compilation time, the Stemcell version gets checked and the only the appropriate openldap version gets compiled.