### PR TITLE
fix: NFS-volume service nfsbroker cred leak

### DIFF
--- a/jobs/nfsbrokerpush/templates/manifest.yml.erb
+++ b/jobs/nfsbrokerpush/templates/manifest.yml.erb
@@ -8,7 +8,7 @@
   end
 
   if uaa_client_id == '' || uaa_client_secret == ''
-    raise 'missing credhub uaa credentials'
+    raise 'missing credhub UAA credentials'
   end
 -%>
 ---

--- a/jobs/nfsbrokerpush/templates/manifest.yml.erb
+++ b/jobs/nfsbrokerpush/templates/manifest.yml.erb
@@ -1,3 +1,16 @@
+<%
+  uaa_client_id = ''
+  uaa_client_secret = ''
+
+  if_p('nfsbrokerpush.credhub.uaa_client_id', 'nfsbrokerpush.credhub.uaa_client_secret') do |client_id, client_secret|
+    uaa_client_id = client_id
+    uaa_client_secret = client_secret
+  end
+
+  if uaa_client_id == '' || uaa_client_secret == ''
+    raise 'missing credhub uaa credentials'
+  end
+-%>
 ---
 applications:
 - name: "<%= p('nfsbrokerpush.app_name') %>"
@@ -9,3 +22,5 @@ applications:
   env:
     USERNAME: "<%= p('nfsbrokerpush.username') %>"
     PASSWORD: "<%= p('nfsbrokerpush.password') %>"
+    UAA_CLIENT_ID: "<%= uaa_client_id %>"
+    UAA_CLIENT_SECRET: "<%= uaa_client_secret %>"

--- a/jobs/nfsbrokerpush/templates/start.sh.erb
+++ b/jobs/nfsbrokerpush/templates/start.sh.erb
@@ -5,8 +5,6 @@
   end
 
   credhub_url = ''
-  uaa_client_id = ''
-  uaa_client_secret = ''
 
   if link('credhub').instances.length > 0
     credhub_url = link('credhub').p('credhub.internal_url')+":"+link('credhub').p('credhub.port').to_s
@@ -16,26 +14,19 @@
     end
   end
 
-  if_p('nfsbrokerpush.credhub.uaa_client_id', 'nfsbrokerpush.credhub.uaa_client_secret') do |client_id, client_secret|
-    uaa_client_id = client_id
-    uaa_client_secret = client_secret
-  end
-
   allowed_options = 'source,uid,gid,auto_cache,readonly,version,mount,cache'
 
   if p('nfsbrokerpush.ldap_enabled')
     allowed_options = 'source,auto_cache,username,password,readonly,version,mount,cache'
   end
   
-  if credhub_url == '' || uaa_client_id == '' || uaa_client_secret == ''
-    raise 'missing credhub uaa properties'
+  if credhub_url == ''
+    raise 'missing credhub URL'
   end
 %>
 bin/nfsbroker --listenAddr="0.0.0.0:$PORT" \
               --servicesConfig="./services.json" \
               --credhubURL="<%= credhub_url %>" \
-              --uaaClientID="<%= uaa_client_id %>" \
-              --uaaClientSecret="<%= uaa_client_secret %>" \
               --storeID="<%= p('nfsbrokerpush.store_id') %>" \
               --logLevel="<%= p("nfsbrokerpush.log_level") %>" \
               --timeFormat="<%= p("nfsbrokerpush.log_time_format") %>" \

--- a/spec/jobs/nfsbrokerpush/manifest_yml_spec.rb
+++ b/spec/jobs/nfsbrokerpush/manifest_yml_spec.rb
@@ -1,0 +1,81 @@
+require 'rspec'
+require 'bosh/template/test'
+
+describe 'nfsbrokerpush job' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../../..')) }
+  let(:job) { release.job('nfsbrokerpush') }
+
+  describe 'manifest.yml' do
+    let(:template) { job.template('manifest.yml') }
+    let(:credhub_link) { [
+      Bosh::Template::Test::Link.new(
+        name: 'credhub',
+        instances: [Bosh::Template::Test::LinkInstance.new(address: 'credhub.service.cf.internal')],
+        properties: {
+          'credhub' => {
+            'internal_url' => 'some-credhub-url',
+            'port' => 4321,
+            'ca_certificate' => 'some-certificate',
+          }
+        }
+      )
+    ] }
+
+    context 'when fully configured with all required credhub properties' do
+      let(:manifest_properties) do
+        {
+          "nfsbrokerpush" => {
+            "credhub" => {
+              "uaa_client_id" => "client-id",
+              "uaa_client_secret" => "client-secret",
+            },
+            "store_id" => "some-store-id",
+            "log_level" => "some-log-level",
+            "log_time_format" => "some-log-time-format",
+            "app_name" => "super-cool-app",
+            "app_domain" => "cf-domain.test",
+            "username" => "jane-doe",
+            "password" => "fake-secret",
+          }
+        }
+      end
+
+      it 'successfully renders the manifest' do
+        tpl_output = template.render(manifest_properties, consumes: credhub_link)
+
+        expect(tpl_output).to include("---")
+        expect(tpl_output).to include('- name: "super-cool-app"')
+        expect(tpl_output).to include('  buildpacks:')
+        expect(tpl_output).to include('  - binary_buildpack')
+        expect(tpl_output).to include('  routes:')
+        expect(tpl_output).to include('  - route: "super-cool-app.cf-domain.test"')
+        expect(tpl_output).to include('  memory: "256M"')
+        expect(tpl_output).to include('  env:')
+        expect(tpl_output).to include('    USERNAME: "jane-doe"')
+        expect(tpl_output).to include('    PASSWORD: "fake-secret"')
+        expect(tpl_output).to include('    UAA_CLIENT_ID: "client-id"')
+        expect(tpl_output).to include('    UAA_CLIENT_SECRET: "client-secret"')
+      end
+    end
+
+    context 'when UAA properties are missing' do
+      let(:manifest_properties) {
+        {
+          "nfsbrokerpush" => {
+            "store_id" => "some-store-id",
+            "log_level" => "some-log-level",
+            "log_time_format" => "some-log-time-format",
+            "app_name" => "super-cool-app",
+            "app_domain" => "cf-domain.test",
+            "username" => "jane-doe",
+            "password" => "fake-secret",
+          }
+        }
+      }
+
+      it 'should present a meaningful message' do
+        expect {template.render(manifest_properties, consumes: credhub_link) }.to raise_error("missing credhub UAA credentials")
+      end
+    end
+  end
+end

--- a/spec/jobs/nfsbrokerpush/start_sh_spec.rb
+++ b/spec/jobs/nfsbrokerpush/start_sh_spec.rb
@@ -41,8 +41,6 @@ describe 'nfsbrokerpush job' do
 
         expect(tpl_output).to include("bin/nfsbroker --listenAddr=\"0.0.0.0:$PORT\"")
         expect(tpl_output).to include("--credhubURL=\"https://some-credhub-url:4321\"")
-        expect(tpl_output).to include("--uaaClientID=\"client-id\"")
-        expect(tpl_output).to include("--uaaClientSecret=\"client-secret\"")
         expect(tpl_output).to include("--servicesConfig=\"./services.json\"")
         expect(tpl_output).to include("--logLevel=\"some-log-level\"")
         expect(tpl_output).to include("--timeFormat=\"some-log-time-format\"")
@@ -66,8 +64,6 @@ describe 'nfsbrokerpush job' do
         tpl_output = template.render(manifest_properties, consumes: credhub_link)
 
         expect(tpl_output).to include("--credhubURL=\"https://some-credhub-url:4321\"")
-        expect(tpl_output).to include("--uaaClientID=\"some-uaa-client-id\"")
-        expect(tpl_output).to include("--uaaClientSecret=\"some-uaa-client-secret\"")
         expect(tpl_output).to include("--storeID=\"nfsbroker\"")
       end
 
@@ -88,16 +84,6 @@ describe 'nfsbrokerpush job' do
         it 'a meaningful error message is returned' do
           expect{template.render(manifest_properties)}.to raise_error("Can't find link 'credhub'")
         end
-      end
-    end
-
-    context 'when configured with no credhub properties' do
-      let(:manifest_properties) do
-        {}
-      end
-
-      it 'fails with a meaningful error message' do
-        expect { template.render(manifest_properties, consumes: credhub_link) }.to raise_error('missing credhub uaa properties')
       end
     end
 


### PR DESCRIPTION
Render UAA creds into the CF app manifest to avoid them being logged.

[#184812914](https://www.pivotaltracker.com/story/show/184812914)