### PR TITLE
fix failures in ci

### DIFF
--- a/scripts/ci/run_broker_integration
+++ b/scripts/ci/run_broker_integration
@@ -5,6 +5,8 @@ set -e -x
 
 {
     cd credhub
+    # need to patch the script from credhub repo to use the -legacy flag to export the keytool certs, else newer java versions will fail
+    sed -i  's#pass:changeit#pass:changeit -legacy#g' scripts/setup_dev_mtls.sh
     ./scripts/start_server.sh -Dspring.profiles.active=dev,dev-h2 > /tmp/start_credhub.log 2>&1
     kill -9 "$(ps --pid $$ -oppid=)"; exit
 }&

--- a/scripts/ci/run_broker_integration.build.yml
+++ b/scripts/ci/run_broker_integration.build.yml
@@ -4,8 +4,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfpersi/nfs-broker-tests
-    tag: latest
+    repository: bosh/integration
+    tag: main
 
 inputs:
   - name: nfs-volume-release-concourse-tasks


### PR DESCRIPTION
this addresses two issues:

- change to bosh/integration cfpersi/nfs-broker-tests contains go 1.13 and won't compile because it missed os.ReadFile since it still uses the long deprecated (1.17 IIRC) ioutil.ReadFile.

- moving to bosh integration main introduces openssl v3. that will output certs that are not usable by a java 1.8 keytool if the -legacy flag is not provided.