### PR TITLE
fix: remove config file on stop

### DIFF
--- a/jobs/nfsv3driver/templates/drain.erb
+++ b/jobs/nfsv3driver/templates/drain.erb
@@ -67,6 +67,7 @@ fi
 wait_for_apps_to_be_evacuated
 
 echo "rep is done..evacuating nfsv3driver"
+rm -f "<%= p('nfsv3driver.driver_path') %>/nfsv3driver.json"
 
 set +e
 evacuate

--- a/jobs/nfsv3driver/templates/nfsv3driver_ctl.erb
+++ b/jobs/nfsv3driver/templates/nfsv3driver_ctl.erb
@@ -34,6 +34,7 @@ case $1 in
       kill -9 `cat $PIDFILE` || true
       rm -f $PIDFILE
     fi
+    rm -f "<%= p('nfsv3driver.driver_path') %>/nfsv3driver.json"
     ;;
 
   *)


### PR DESCRIPTION
When the NFS driver starts, it creates a config file called `/var/vcap/data/voldrivers/nfsv3driver.json` which contains the network address of the driver amongst other things. This file should be cleaned up when the NFS driver stops so that Diego will no longer try to communicate with the driver.

Resolves #427
Resolves #415

[#185229779]