### PR TITLE
prepare openldap autobumps, introduce openssl3

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -82,7 +82,10 @@ nfs-debs/xenial/rpcbind_0.2.3-0.6_amd64.deb:
   size: 45966
   object_id: 34ce9d16-81b5-4f83-6e52-14259e667a38
   sha: sha256:2338a1e969779c54d40ca9d53deb928afc721524e511dac38be76f1a61540f81
-openldap/openldap-2.4.44.tgz:
-  size: 5658830
-  object_id: daea5917-02c3-4fe5-4626-a8805979788d
-  sha: 016a738d050a68d388602a74b5e991035cdba149
+openldap/openldap-2.5.13.tgz:
+  size: 6454072
+  object_id: 92766a2b-d302-4a56-574e-abdd76726f39
+  sha: sha256:ee3c430c4ef7b87c57b622108c7339376d6c27fbbf2767770be3de1df63d008c
+test-dependencies/openssl-3.tar.gz:
+  size: 15569450
+  sha: sha256:840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -86,10 +86,6 @@ openldap/openldap-2.5.13.tgz:
   size: 6454072
   object_id: 92766a2b-d302-4a56-574e-abdd76726f39
   sha: sha256:ee3c430c4ef7b87c57b622108c7339376d6c27fbbf2767770be3de1df63d008c
-openldap/openldap-2.4.44.tgz:
-  size: 5658830
-  object_id: daea5917-02c3-4fe5-4626-a8805979788d
-  sha: 016a738d050a68d388602a74b5e991035cdba149
 test-dependencies/openssl-3.1.4.tar.gz:
   size: 15569450
   object_id: 8d8e7e08-41bb-4c5c-6bc7-2716daf6cf38

--- a/jobs/nfstestldapserver/templates/bin/ctl
+++ b/jobs/nfstestldapserver/templates/bin/ctl
@@ -8,8 +8,8 @@ source /var/vcap/jobs/nfstestldapserver/helpers/ctl_setup.sh 'nfstestldapserver'
 
 export PORT=${PORT:-5000}
 export LANG=en_US.UTF-8
-
 export OPENLDAP=/var/vcap/packages/openldap
+export LD_LIBRARY_PATH="${OPENLDAP}/openssl3/lib64:${LD_LIBRARY_PATH}"
 export PATH=${OPENLDAP}/libexec:${OPENLDAP}/sbin:$PATH
 
 case $1 in
@@ -39,7 +39,7 @@ case $1 in
       mkdir -p $conf_db
       chown vcap:vcap $conf_db
       echo "Creating config database from $conf_file"
-      sudo slapadd -F $conf_db -n 0 -l $conf_file
+      sudo LD_LIBRARY_PATH=${LD_LIBRARY_PATH} slapadd -F $conf_db -n 0 -l $conf_file
     fi
 
     if [ -n "$SSL_ACTIVE" ]
@@ -49,7 +49,7 @@ case $1 in
       protocols="ldap:///"
     fi
 
-    sudo slapd -h "$protocols" -d stats,acl -F $conf_db >>$LOG_DIR/$JOB_NAME.log 2>&1
+    sudo LD_LIBRARY_PATH=${LD_LIBRARY_PATH} slapd -h "$protocols" -d stats,acl -F $conf_db >>$LOG_DIR/$JOB_NAME.log 2>&1
 
     ;;
 

--- a/jobs/nfstestldapserver/templates/post-start.erb
+++ b/jobs/nfstestldapserver/templates/post-start.erb
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 export OPENLDAP=/var/vcap/packages/openldap
+export LD_LIBRARY_PATH="${OPENLDAP}/openssl3/lib64:${LD_LIBRARY_PATH}"
 export PATH=${OPENLDAP}/libexec:${OPENLDAP}/sbin:${OPENLDAP}/bin:$PATH
 
 pushd /var/vcap/jobs/nfstestldapserver/config/
-ldapadd -x -w secret -h 127.0.0.1 -p 389 -D "cn=admin,dc=domain,dc=com" -f addou.ldif
-ldapadd -x -w secret -h 127.0.0.1 -p 389 -D "cn=admin,dc=domain,dc=com" -f adduser.ldif
-
+  ldapadd -x -w secret -h 127.0.0.1 -p 389 -D "cn=admin,dc=domain,dc=com" -f addou.ldif
+  ldapadd -x -w secret -h 127.0.0.1 -p 389 -D "cn=admin,dc=domain,dc=com" -f adduser.ldif
+popd
 exit 0

--- a/jobs/nfstestldapserver/templates/post-start.erb
+++ b/jobs/nfstestldapserver/templates/post-start.erb
@@ -5,7 +5,7 @@ export LD_LIBRARY_PATH="${OPENLDAP}/openssl3/lib64:${LD_LIBRARY_PATH}"
 export PATH=${OPENLDAP}/libexec:${OPENLDAP}/sbin:${OPENLDAP}/bin:$PATH
 
 pushd /var/vcap/jobs/nfstestldapserver/config/
-  ldapadd -x -w secret -h 127.0.0.1 -p 389 -D "cn=admin,dc=domain,dc=com" -f addou.ldif
-  ldapadd -x -w secret -h 127.0.0.1 -p 389 -D "cn=admin,dc=domain,dc=com" -f adduser.ldif
+  ldapadd -x -w secret -H ldap://127.0.0.1:389 -D "cn=admin,dc=domain,dc=com" -f addou.ldif
+  ldapadd -x -w secret -H ldap://127.0.0.1:389 -D "cn=admin,dc=domain,dc=com" -f adduser.ldif
 popd
 exit 0

--- a/packages/openldap/packaging
+++ b/packages/openldap/packaging
@@ -1,20 +1,42 @@
+#!/usr/bin/env bash 
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
 # Detect # of CPUs so make jobs can be parallelized
 CPUS=$(grep -c ^processor /proc/cpuinfo)
- # Available variables
+
+# Available variables
 # $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
-export HOME=/var/vcap
-export BDB_PATH=/var/vcap/packages/berkeleydb
+
+# Both the below compilation items are test dependencies. The reason you see openssl3
+# in here is that the openssl version shipped with xenial stemcells was too old to
+# to compile > openldap-2.4.44 on 2023/11/01. Instead of adding logic to handle xenial vs.
+# newer stemcell versions we opted to exchange the openssl it is compiled against to avoid
+# complexity. We judged it safe since these test dependencies should not be able to
+# interfere with production deployments.
+
+tar xvf test-dependencies/openssl-3*.tar.gz
+pushd openssl-3*
+  ./Configure \
+    --prefix=${BOSH_INSTALL_TARGET}/openssl3 \
+    --openssldir=${BOSH_INSTALL_TARGET}/openssl3 \
+    enable-fips \
+
+  make
+  make install
+popd
 
 cd $BOSH_COMPILE_TARGET
-tar -xzvf openldap/openldap-2.4.44.tgz
-cd openldap-2.4.44
+tar -xzvf openldap/openldap*.tgz
+pushd openldap-*
+  export HOME=/var/vcap
+  export BDB_PATH=/var/vcap/packages/berkeleydb
+  export CPPFLAGS="-I ${BDB_PATH}/include -I ${BOSH_INSTALL_TARGET}/openssl3/include"
+  export LDFLAGS=-L${BOSH_INSTALL_TARGET}/openssl3/lib64
+  export LD_LIBRARY_PATH="${BDB_PATH}/lib"
 
-export CPPFLAGS="-I ${BDB_PATH}/include"
-export LD_LIBRARY_PATH="${BDB_PATH}/lib"
-./configure --prefix=${BOSH_INSTALL_TARGET}
+  ./configure --prefix=${BOSH_INSTALL_TARGET}
 
-make depend && make && make install
+  make depend && make && make install
+popd

--- a/packages/openldap/spec
+++ b/packages/openldap/spec
@@ -2,4 +2,5 @@
 name: openldap
 dependencies: [berkeleydb]
 files:
-- openldap/openldap-2.4.44.tgz
+- openldap/openldap-*.tgz
+- test-dependencies/openssl-3*.tar.gz


### PR DESCRIPTION
[#184823353]

Previously we had to pin back openldap because of the availble version of openssl in xenial stemcells. Openldap > 2.4.44 stopped being able to compile against the Openssl version present on xenial stemcells.

This can be mitigated by introducing the openssl blob to allow for further bumping openldap blob. Since openldap itself is not part of a production environment that deploys this release but is used exclusively in testing, adding a non system openssl version should be safe

On Nov. 1st 2023 we opted to not introduce a stemcell version dependent compilation of openldap because it was judged that this would add more complexity than introducing openssl3 blob to the compilation of openldap.

to avoid having two version lines of openldap to support tests on xenial, the openssl blob was introduced in a previous commit. This commit updates the job for the openldap package to ensure that the custom openssl is used.

Additionally this simplifies the naming scheme of the actual package to exclude the version number of openldap to avoid having to change job manifests on package bumps. This is done to ensure compatibility of the bosh release with the cryogenics bosh release blob bump framework. Currently the blobs are bumped by a custom task sourced from this repo and this will be removed to simplify maintenance of this release.