### PR TITLE
v5 do not use debian packages

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,86 +2,42 @@ berkeleydb/db-5.3.28.tar.gz:
   size: 35090431
   object_id: 3ad9234b-50b7-4f58-7d46-d3569f90d3d6
   sha: fa3f8a41ad5101f43d08bc0efb6241c9b6fc1ae9
-nfs-debs/bionic/keyutils_1.5.9-9.2ubuntu2_amd64.deb:
-  size: 47896
-  object_id: b1c4adab-3acd-45f9-5558-d893ab0a2937
-  sha: sha256:223a7160b6e2680d2b1f43abb067e0ccc08906bb2c5448ad4b3065f38309bbb5
-nfs-debs/bionic/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb:
-  size: 133328
-  object_id: c7db62da-06d2-4ee8-6508-9c3daf9883db
-  sha: sha256:76bc94b3bb4356673c61dd2a4a7b06f40de21dab051aa4b31282aa9d7798b383
-nfs-debs/bionic/libnfsidmap2_0.25-5.1_amd64.deb:
-  size: 27180
-  object_id: ac0a86ba-ef76-4d1c-6e61-2e2dfcfd511c
-  sha: sha256:ae6eaf479efa010b313b4e0cf18812e3ca6eb50b6392b7b52e854d6acafe866b
-nfs-debs/bionic/nfs-common_1.3.4-2.1ubuntu5.5_amd64.deb:
-  size: 205604
-  object_id: 8f569ad0-56c5-4bf2-4b8a-8ad9c077f013
-  sha: sha256:e5c2638a36827b3b7817cd8d4bf0bfa60c4e88f70d45e89a53b50cb98bad029e
-nfs-debs/bionic/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb:
-  size: 42124
-  object_id: fa159f54-edd0-4e78-7393-cda37ca9c7e0
-  sha: sha256:ad1e5849523af0dba54a1f7e7f54d11f1a7a0131ce5de858a5ff37e61c27b35d
-nfs-debs/jammy/keyutils_1.6.1-2ubuntu3_amd64.deb:
-  size: 50410
-  object_id: 6a525e94-1a19-4da7-5b9c-8f90509b6681
-  sha: sha256:39da334791f57894fa13f680470e048383074b6c02aeb58e206033c5a3d0e925
-nfs-debs/jammy/libevent-2.1-7_2.1.12-stable-1build3_amd64.deb:
-  size: 148238
-  object_id: 2dea972e-5825-485d-5287-67d20fe2d7cb
-  sha: sha256:e13aac87e4143293cf1d3cb82a2458fbeacc234d0db0667fd5567bdcd6da15fe
-nfs-debs/jammy/libnfsidmap2_0.25-6build1_amd64.deb:
-  size: 27896
-  object_id: 941ca15d-7c40-4533-67a2-a23af0978300
-  sha: sha256:a6d3c6b8db27c51d9aabcba372c626726648c6b60d7b94aa962a4465ec23ae5a
-nfs-debs/jammy/nfs-common_1.3.4-6ubuntu1_amd64.deb:
-  size: 219244
-  object_id: f767427a-61b5-4686-5352-d8c91acceba3
-  sha: sha256:291ebf25f5c811f51382f3d2dca4972a71ceedfd19ad72c56db716e7669a0598
-nfs-debs/jammy/rpcbind_1.2.6-2build1_amd64.deb:
-  size: 46608
-  object_id: 6b175861-ab18-4247-6e08-7c69c25f0efe
-  sha: sha256:40f5113c7d8711c2ac8ad50ffee7fa0890731e22da0a99bee3fbc6cdd1f451ac
-nfs-debs/xenial/keyutils_1.5.9-8ubuntu1_amd64.deb:
-  size: 47054
-  object_id: 79ec8102-01f0-4e62-7d5a-cac385c29c03
-  sha: ec2e96e73feb5215605c9f0254cad05d9cc5688a
-nfs-debs/xenial/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb:
-  size: 133328
-  object_id: c1fc2753-6049-4791-4233-3bb002100204
-  sha: sha256:76bc94b3bb4356673c61dd2a4a7b06f40de21dab051aa4b31282aa9d7798b383
-nfs-debs/xenial/libgssapi-krb5-2_1.15.1-2_amd64.deb:
-  size: 120298
-  object_id: 00800a67-3797-4f5a-6cf5-e2f8a4290d85
-  sha: sha256:07affb4998cbd57d9d125349213cde5a191a5bb466f9085333c87d2a6b252648
-nfs-debs/xenial/libk5crypto3_1.15.1-2_amd64.deb:
-  size: 84942
-  object_id: 461520bc-8f33-4c19-7f13-fffa143614cb
-  sha: sha256:f52e197b56ddfa20159a9f4967b87dc29a1987ea4a48acd159512761c4ae51e4
-nfs-debs/xenial/libkrb5-3_1.15.1-2_amd64.deb:
-  size: 276254
-  object_id: e8d2e2aa-647a-45fd-53f1-b8d1199718b3
-  sha: sha256:6613a940c56a785724e330645fd9ac9bf493b849cbb63c541b7a6ce1b426a99d
-nfs-debs/xenial/libkrb5support0_1.15.1-2_amd64.deb:
-  size: 32158
-  object_id: 721c58f2-7b41-4736-40f0-9fc36ea629c6
-  sha: sha256:da7fd6c191485c6c64b484368a77f3cbbe2d0729f858045ea4182df09f77ba3a
-nfs-debs/xenial/libnfsidmap2_0.25-5_amd64.deb:
-  size: 32182
-  object_id: d666fb5d-2e46-4bb1-6dba-b2e6368c6048
-  sha: f28b7370542daaf81cefb44d9057fa9b3fb43064
-nfs-debs/xenial/libtirpc1_0.2.5-1.2+deb9u1_amd64.deb:
-  size: 80634
-  object_id: 671095cf-0251-4aab-63a8-ee86f9ec150d
-  sha: sha256:2176796081db99169c578dbfc1d958e2170047be7bff9722350204953623be44
-nfs-debs/xenial/nfs-common_1.3.4-2.1ubuntu4_amd64.deb:
-  size: 205360
-  object_id: 79011511-3a38-4446-4521-c05ff6ecfc63
-  sha: sha256:d241607dacc6c922852e6d7ff7805912ba7cb1f8463e4e23033caac34481456c
-nfs-debs/xenial/rpcbind_0.2.3-0.6_amd64.deb:
-  size: 45966
-  object_id: 34ce9d16-81b5-4f83-6e52-14259e667a38
-  sha: sha256:2338a1e969779c54d40ca9d53deb928afc721524e511dac38be76f1a61540f81
+nfs-debs/libevent-2.1.12-stable.tar.gz:
+  size: 1100847
+  object_id: de54df99-f627-4e40-68b6-eb3addfa785a
+  sha: sha256:92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
+nfs-debs/libtirpc-1.3.4.tar.bz2:
+  size: 563292
+  object_id: 2994e47f-f2f3-4756-5fee-40626caf879c
+  sha: sha256:1e0b0c7231c5fa122e06c0609a76723664d068b0dba3b8219b63e6340b347860
+nfs-debs/nfs-utils-2.6.2.tar.xz:
+  size: 1370282
+  object_id: d85f1bcc-9f7a-40fd-560d-62561c494c99
+  sha: sha256:45ad39b54b60aa9c71d1447c1321b9d799369a018990b3641bfeefbcc0b096a7
+nfs-debs/rpcbind-1.2.6-vulnerability_fixes-1.patch:
+  size: 938
+  object_id: e903bdf9-3746-42cc-7799-a8fc18ce7899
+  sha: sha256:17a15acdabcf2bfc648af9197bbae8d1bcc1e22215b3d5cf9ff60533bf6522e4
+nfs-debs/rpcbind-1.2.6.tar.bz2:
+  size: 124590
+  object_id: 21cf96a5-d367-4204-4bbf-188d1167e643
+  sha: sha256:5613746489cae5ae23a443bb85c05a11741a5f12c8f55d2bb5e83b9defeee8de
+nfs-debs/rpcsvc-proto-1.4.4.tar.xz:
+  size: 168648
+  object_id: 0031d8cb-2639-4b77-64f9-0e821bee9808
+  sha: sha256:81c3aa27edb5d8a18ef027081ebb984234d5b5860c65bd99d4ac8f03145a558b
+nfs-debs/sqlite-3.44.0.tar.gz:
+  size: 12706126
+  object_id: b84f66d4-b415-483c-6096-076e09b1a9d0
+  sha: sha256:a63190f3abc48189f3d7f544d7c18b73e042d4ddc520ebb57071e48417c5607c
+nfs-debs/tcl8.6.13-src.tar.gz:
+  size: 10834396
+  object_id: 895e8409-f00b-4dcd-75c0-346bb625ff6f
+  sha: sha256:43a1fae7412f61ff11de2cfd05d28cfc3a73762f354a417c62370a54e2caf066
+nfs-debs/util-linux-2.39.tar.gz:
+  size: 17422555
+  object_id: 68a5e840-33e3-4a3e-4394-a29faff88e1e
+  sha: sha256:b1f597ad172a2ee17b0a7ae4be7ab7e1b1a6f9394ddbd3d8ec90ae4ed7333579
 openldap/openldap-2.6.6.tgz:
   size: 6475109
   object_id: bde84a3d-6472-493d-7717-3ad348e1b227

--- a/jobs/nfsv3driver/monit
+++ b/jobs/nfsv3driver/monit
@@ -5,4 +5,10 @@ check process nfsv3driver
   start program "/var/vcap/jobs/nfsv3driver/bin/nfsv3driver_ctl start"
   stop program "/var/vcap/jobs/nfsv3driver/bin/nfsv3driver_ctl stop"
   group vcap
+check process statd matching rpc.statd
+  start program "/var/vcap/jobs/nfsv3driver/bin/statd_ctl start"
+  stop program "/var/vcap/jobs/nfsv3driver/bin/statd_ctl stop"
+  if failed port <%= p("nfsv3driver.statd_port") %> then restart
+  group vcap
 <% end %>
+

--- a/jobs/nfsv3driver/spec
+++ b/jobs/nfsv3driver/spec
@@ -11,6 +11,7 @@ templates:
   ctl.erb: bin/nfsv3driver_ctl
   start.sh.erb: bin/start.sh
   drain.erb: bin/drain
+  statd.erb: bin/statd_ctl
 
 packages:
 - nfs-debs
@@ -21,6 +22,9 @@ consumes:
   type: mapfs
 
 properties:
+  nfsv3driver.statd_port:
+    description: "port rpc-statd listens on"
+    default: 60000
   nfsv3driver.listen_addr:
     description: "address nfsv3driver listens on"
     default: "127.0.0.1:7589"

--- a/jobs/nfsv3driver/templates/install.erb
+++ b/jobs/nfsv3driver/templates/install.erb
@@ -4,83 +4,6 @@
 <% else %>
 set -eo pipefail
 
-install_if_missing ()
-{
-    echo "Installing $1"
-
-    set +eo pipefail
-    dpkg -s $1 2>&1
-    dpkg_installed=$(echo $?)
-    if [ "$dpkg_installed" != "0" ]; then
-        for x in `seq 1 100` :
-        do
-          dpkg --force-confdef -i $2 2>&1
-          if [ $? -ne 0 ] ; then
-            sleep 3
-          else
-           set -eo pipefail
-           return 0
-          fi
-        done
-        set -eo pipefail
-        lsof -n
-        exit 1
-    else
-        echo "Skipping $1"
-    fi
-    set -eo pipefail
-}
-
-install_or_upgrade ()
-{
-    echo "Upgrading $1"
-
-    set +eo pipefail
-
-    for x in `seq 1 100` :
-    do
-      dpkg --force-confdef -i $2 2>&1
-      if [ $? -ne 0 ] ; then
-        sleep 3
-      else
-       set -eo pipefail
-       return 0
-      fi
-    done
-    set -eo pipefail
-    lsof -n
-    exit 1
-    set -eo pipefail
-}
-
-configure_if_present ()
-{
-    echo "Configuring $1"
-
-    set +eo pipefail
-    dpkg -s $1 2>&1
-    dpkg_installed=$(echo $?)
-    if [ "$dpkg_installed" == "0" ]; then
-        for x in `seq 1 100` :
-        do
-          dpkg --configure $1 2>&1 | grep 'is already installed and configured'
-          if [ $? -ne 0 ] ; then
-            sleep 3
-          else
-           set -eo pipefail
-           return 0
-          fi
-        done
-        set -eo pipefail
-        lsof -n
-        exit 1
-    else
-        echo "Skipping $1"
-    fi
-    set -eo pipefail
-}
-
-
 function copy_client_certs_to_spec_dir() {
   local cert_dir="<%= p('nfsv3driver.driver_path') %>/certs/nfsv3driver"
 
@@ -95,57 +18,12 @@ function prepend_rfc3339_datetime() {
 }
 
 function main() {
-  codename=$(lsb_release -c | cut -f 2 )
-  echo "Installing NFS packages ${codename}"
-  case ${codename} in
-  "jammy")
-    (
-    flock -x 200
-    install_if_missing keyutils /var/vcap/packages/nfs-debs/$codename/keyutils_1.6.1-2ubuntu3_amd64.deb
-    install_if_missing libevent-2.1-6 /var/vcap/packages/nfs-debs/$codename/libevent-2.1-7_2.1.12-stable-1build3_amd64.deb
-    install_if_missing libnfsidmap2 /var/vcap/packages/nfs-debs/$codename/libnfsidmap2_0.25-6build1_amd64.deb
-    configure_if_present libk5crypto3
-    configure_if_present libkrb5-3
-    configure_if_present libgssapi-krb5-2
-    configure_if_present libtirpc1
-    install_or_upgrade rpcbind /var/vcap/packages/nfs-debs/$codename/rpcbind_1.2.6-2build1_amd64.deb
-    install_or_upgrade nfs-common /var/vcap/packages/nfs-debs/$codename/nfs-common_1.3.4-6ubuntu1_amd64.deb
-    ) 200>/var/vcap/data/dpkg.lock
-  ;;
-  "bionic")
-    (
-    flock -x 200
-    install_if_missing keyutils /var/vcap/packages/nfs-debs/$codename/keyutils_1.5.9-9.2ubuntu2_amd64.deb
-    install_if_missing libevent-2.1-6 /var/vcap/packages/nfs-debs/$codename/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb
-    install_if_missing libnfsidmap2 /var/vcap/packages/nfs-debs/$codename/libnfsidmap2_0.25-5.1_amd64.deb
-    configure_if_present libk5crypto3
-    configure_if_present libkrb5-3
-    configure_if_present libgssapi-krb5-2
-    configure_if_present libtirpc1
-    install_or_upgrade rpcbind /var/vcap/packages/nfs-debs/$codename/rpcbind_0.2.3-0.6ubuntu0.18.04.4_amd64.deb
-    install_or_upgrade nfs-common /var/vcap/packages/nfs-debs/$codename/nfs-common_1.3.4-2.1ubuntu5.5_amd64.deb
-    ) 200>/var/vcap/data/dpkg.lock
-  ;;
-  "xenial")
-    (
-    flock -x 200
-    install_if_missing keyutils /var/vcap/packages/nfs-debs/$codename/keyutils_1.5.9-8ubuntu1_amd64.deb
-    install_if_missing libevent-2.1-6 /var/vcap/packages/nfs-debs/$codename/libevent-2.1-6_2.1.8-stable-4build1_amd64.deb
-    install_if_missing libnfsidmap2 /var/vcap/packages/nfs-debs/$codename/libnfsidmap2_0.25-5_amd64.deb
-    install_or_upgrade libkrb5support0 /var/vcap/packages/nfs-debs/$codename/libkrb5support0_1.15.1-2_amd64.deb
-    install_or_upgrade libk5crypto3 /var/vcap/packages/nfs-debs/$codename/libk5crypto3_1.15.1-2_amd64.deb
-    install_or_upgrade libkrb5-3 /var/vcap/packages/nfs-debs/$codename/libkrb5-3_1.15.1-2_amd64.deb
-    configure_if_present libkrb5-3
-    install_or_upgrade libgssapi-krb5-2 /var/vcap/packages/nfs-debs/$codename/libgssapi-krb5-2_1.15.1-2_amd64.deb
-    install_or_upgrade libtirpc1 /var/vcap/packages/nfs-debs/$codename/libtirpc1_0.2.5-1.2+deb9u1_amd64.deb
-    install_or_upgrade rpcbind /var/vcap/packages/nfs-debs/$codename/rpcbind_0.2.3-0.6_amd64.deb
-    install_or_upgrade nfs-common /var/vcap/packages/nfs-debs/$codename/nfs-common_1.3.4-2.1ubuntu4_amd64.deb
-    ) 200>/var/vcap/data/dpkg.lock
-  ;;
-  esac
-
   echo "Copying client certs to data directory..."
   copy_client_certs_to_spec_dir
+  if [[ ! -f /sbin/mount.nfs ]]; then
+  echo "Creating symlinks to nfs-utils sbins from package dir"
+    ln -s /var/vcap/packages/nfs-debs/sbin/mount.nfs /sbin/mount.nfs
+  fi
 
   exit 0
 }

--- a/jobs/nfsv3driver/templates/start.sh.erb
+++ b/jobs/nfsv3driver/templates/start.sh.erb
@@ -7,7 +7,6 @@ SERVER_CERTS_DIR=/var/vcap/jobs/nfsv3driver/config/certs
 LOG_DIR=/var/vcap/sys/log/nfsv3driver
 RUN_DIR=/var/vcap/sys/run/nfsv3driver
 PIDFILE=$RUN_DIR/nfsv3driver.pid
-
 mkdir -p $LOG_DIR
 chown -R vcap:vcap $LOG_DIR
 

--- a/jobs/nfsv3driver/templates/statd.erb
+++ b/jobs/nfsv3driver/templates/statd.erb
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p /var/vcap/sys/log/statd
+exec 1>> /var/vcap/sys/log/statd/statd.log
+exec 2>> /var/vcap/sys/log/statd/statd.err.log
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/var/vcap/packages/nfs-debs/lib
+echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ `basename $0` $* --------------" | tee /dev/stderr
+
+case $1 in
+  start)
+    mkdir -p /var/vcap/data/rpc_statd/sm
+
+    if [[ ! -f /sbin/sm-notify ]]; then
+      ln -s /var/vcap/packages/nfs-debs/sbin/sm-notify /sbin/sm-notify
+    fi
+
+    echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ starting rpcbind  --------------" | tee /dev/stdout
+    /var/vcap/packages/nfs-debs/sbin/rpcbind 
+    echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ starting statd  --------------" | tee /dev/stdout
+    /var/vcap/packages/nfs-debs/sbin/rpc.statd -p <%= p("nfsv3driver.statd_port") %> -P /var/vcap/data/rpc_statd
+    ;;
+
+  stop)
+    echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ stopping rpcbind  --------------" | tee /dev/stdout
+    pkill rpc.statd
+    echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ stopping rpcbind  --------------" | tee /dev/stdout
+    pkill rpcbind
+    ;;
+
+  *)
+    echo "Usage: statd_ctl {start|stop}"
+    ;;
+esac

--- a/packages/nfs-debs/packaging
+++ b/packages/nfs-debs/packaging
@@ -2,4 +2,128 @@
 
 set -e
 
-cp -ra ${BOSH_COMPILE_TARGET}/nfs-debs/* ${BOSH_INSTALL_TARGET}/
+
+#extract all the things
+
+pushd ${BOSH_COMPILE_TARGET}
+  ls nfs-debs/*.tar.gz | xargs -n1 tar -xzf
+  ls nfs-debs/*.tar.bz2 | xargs -n1 tar -xjf
+  ls nfs-debs/*.tar.xz | xargs -n1 tar -xf
+popd
+
+#required to compile sqlite on xenial, configure fails without
+pushd ${BOSH_COMPILE_TARGET}/tcl*/unix
+  ./configure   --prefix=${BOSH_INSTALL_TARGET}
+  make
+  make install
+  export PATH=$BOSH_INSTALL_TARGET/bin:$PATH
+popd
+echo "TCL done"
+pushd ${BOSH_COMPILE_TARGET}/sqlite-*/
+  ./configure \
+    --prefix=${BOSH_INSTALL_TARGET}     \
+    --disable-static  \
+    --enable-fts{4,5} \
+    CPPFLAGS="-DSQLITE_ENABLE_COLUMN_METADATA=1 \
+      -DSQLITE_ENABLE_UNLOCK_NOTIFY=1   \
+      -DSQLITE_ENABLE_DBSTAT_VTAB=1     \
+      -DSQLITE_SECURE_DELETE=1          \
+      -DSQLITE_ENABLE_FTS3_TOKENIZER=1"
+  make
+  make install
+popd
+echo "SQLITE done"
+# libevent
+pushd ${BOSH_COMPILE_TARGET}/libevent-*-stable/
+  # no binary 'python' on $PATH, but python3 is available
+  sed -i 's/python/&3/' event_rpcgen.py
+  ./configure --prefix=${BOSH_INSTALL_TARGET} --disable-static
+  make
+  make install
+popd
+echo "LIBEVENT done"
+# rpcsvc-proto
+pushd ${BOSH_COMPILE_TARGET}/rpcsvc-proto-*/
+  ./configure --prefix=${BOSH_INSTALL_TARGET} --sysconfdir=${BOSH_INSTALL_TARGET}/etc
+  make
+  make install
+popd
+echo "RPCSVC done"
+
+#libtirpc
+pushd  ${BOSH_COMPILE_TARGET}/libtirpc-*/
+  ./configure --prefix=${BOSH_INSTALL_TARGET} \
+              --sysconfdir=${BOSH_INSTALL_TARGET}/etc \
+              --disable-static \
+              --disable-gssapi 
+  make
+  make install
+popd 
+echo "LIBTIRPC done"
+
+#linux-utils
+
+pushd ${BOSH_COMPILE_TARGET}/util-linux-*/
+
+  ./configure   \
+    --prefix=${BOSH_INSTALL_TARGET}   \
+    --libdir=${BOSH_INSTALL_TARGET}/lib   \
+    --sysconfdir=${BOSH_INSTALL_TARGET}/etc   \
+    --localstatedir=${BOSH_INSTALL_TARGET}/var   \
+    --mandir=${BOSH_INSTALL_TARGET}/man   \
+    --infodir=${BOSH_INSTALL_TARGET}/info   \
+    --docdir=${BOSH_INSTALL_TARGET}/doc/util-linux   \
+    --enable-libblkid   \
+    --enable-libmount   \
+    --enable-libuuid   \
+    --enable-blkid   \
+    --enable-mount   \
+    --enable-uuid \
+    --enable-shared   \
+    --disable-all-programs   \
+    --without-python
+    make
+    make install
+popd
+# rpc-bind ( required for some nfsv3 mounts to work
+
+#These flags are required for rpcbind and nfs-utils
+
+export C_INCLUDE_PATH="${BOSH_INSTALL_TARGET}/include:${BOSH_INSTALL_TARGET}/include/tirpc"
+export CPLUS_INCLUDE_PATH="${BOSH_INSTALL_TARGET}/include:${BOSH_INSTALL_TARGET}/include/tirpc"
+export CFLAGS=-L${BOSH_INSTALL_TARGET}/lib
+export TIRPC_CFLAGS="-L${BOSH_INSTALL_TARGET}/lib -I${BOSH_INSTALL_TARGET}/include"
+export TIRPC_LIBS="-L${BOSH_INSTALL_TARGET}/lib -I${BOSH_INSTALL_TARGET}/include"
+
+pushd  ${BOSH_COMPILE_TARGET}/rpcbind-*/
+  sed -i "/servname/s:rpcbind:sunrpc:" src/rpcbind.c
+  patch -Np1 -i ${BOSH_COMPILE_TARGET}/nfs-debs/rpcbind-1.2.6-vulnerability_fixes-1.patch 
+
+  ./configure \
+            --prefix=${BOSH_INSTALL_TARGET}/                                \
+            --bindir=${BOSH_INSTALL_TARGET}/sbin                             \
+            --with-rpcuser=root                            \
+            --enable-warmstarts                            \
+            --without-systemdsystemunitdir \
+            LIBS="-L${BOSH_INSTALL_TARGET}/lib -ltirpc"
+  make
+  make install
+popd
+
+# nfs-utils
+export LIBMOUNT_CFLAGS="-L${BOSH_INSTALL_TARGET}/lib -I${BOSH_INSTALL_TARGET}/include"
+export LIBMOUNT_LIBS="-L${BOSH_INSTALL_TARGET}/lib -I${BOSH_INSTALL_TARGET}/include"
+
+pushd  ${BOSH_COMPILE_TARGET}/nfs-utils-*/
+./configure --prefix=${BOSH_INSTALL_TARGET}          \
+          --sysconfdir=${BOSH_INSTALL_TARGET}/etc      \
+          --disable-sbin-override  \
+          --bindir=${BOSH_INSTALL_TARGET}/bin \
+          --sbindir=${BOSH_INSTALL_TARGET}/sbin    \
+          --disable-nfsv4        \
+          --disable-gss          \
+          LIBS="-L${BOSH_INSTALL_TARGET}/lib -L${BOSH_INSTALL_TARGET}/lib/sqlite3.40.0 -lmount -levent_core  -lsqlite3 -ltirpc"
+make
+make install
+
+popd

--- a/packages/nfs-debs/spec
+++ b/packages/nfs-debs/spec
@@ -2,4 +2,4 @@
 name: nfs-debs
 
 files:
-- nfs-debs/**/*
+- nfs-debs/**

--- a/src/bosh_release/bosh_release_test.go
+++ b/src/bosh_release/bosh_release_test.go
@@ -28,7 +28,6 @@ var _ = Describe("BoshReleaseTest", func() {
 		unstubSleep()
 	})
 
-
 	Context("with no other cloud foundry control components", func() {
 		It("should succeed deploying", func() {
 			session, err := deploy("./operations/remove-credhub.yml", "./operations/remove-nfsbrokerpush.yml")
@@ -38,117 +37,9 @@ var _ = Describe("BoshReleaseTest", func() {
 	})
 
 	It("should have a nfsv3driver process running", func() {
-		libtirpc1VersionRegex := `0.2.5-1.2\+deb9u1`
-		expectDpkgInstalled("libtirpc1", libtirpc1VersionRegex)
-		expectDpkgInstalled("rpcbind", "0.2.3-0.6")
-		expectDpkgInstalled("keyutils", "1.5.9-8ubuntu1")
-		expectDpkgInstalled("libevent-2.1-6", "2.1.8-stable-4build1")
-		expectDpkgInstalled("libnfsidmap2", "0.25-5")
-		expectDpkgInstalled("libkrb5support0", "1.15.1-2")
-		expectDpkgInstalled("libk5crypto3", "1.15.1-2")
-		expectDpkgInstalled("libkrb5-3", "1.15.1-2")
-		expectDpkgInstalled("libgssapi-krb5-2", "1.15.1-2")
-		expectDpkgInstalled("nfs-common", "1:1.3.4-2.1ubuntu4")
-
 		state := findProcessState("nfsv3driver")
 
 		Expect(state).To(Equal("running"))
-	})
-
-	Context("when an existing package is already installed", func() {
-		BeforeEach(func() {
-			cmd := exec.Command("bosh", "-d", "bosh_release_test", "ssh", "nfsv3driver", "-c", "sudo dpkg -P nfs-common")
-			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(session).Should(gexec.Exit(0))
-
-			cmd = exec.Command("bosh", "-d", "bosh_release_test", "ssh", "nfsv3driver", "-c", "sudo apt-get update && sudo apt-get install -y nfs-common")
-			session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(session).Should(gexec.Exit(0))
-		})
-
-		It("should upgrade the nfs-common package to the version specified in the pre-install script", func() {
-			expectDpkgInstalled("nfs-common", "1:1.2.8-9ubuntu12.3")
-
-			cmd := exec.Command("bosh", "-d", "bosh_release_test", "ssh", "nfsv3driver", "-c", "sudo /var/vcap/jobs/nfsv3driver/bin/pre-start")
-			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(session).Should(gexec.Exit(0))
-
-			expectDpkgInstalled("nfs-common", "1:1.3.4-2.1ubuntu4")
-		})
-	})
-
-	Context("when nfsv3driver is disabled", func() {
-		BeforeEach(func() {
-			cmd := exec.Command("bosh", "-d", "bosh_release_test", "delete-deployment", "-n")
-			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(session).Should(gexec.Exit(0))
-
-			ensureDeploy("./operations/disable-nfsv3driver.yml")
-		})
-
-
-		It("should not install packages or run rpcbind", func() {
-			expectDpkgNotInstalled("libtirpc1")
-			expectDpkgNotInstalled("rpcbind")
-			expectDpkgNotInstalled("keyutils")
-			expectDpkgNotInstalled("libevent-2.1-6")
-			expectDpkgNotInstalled("libnfsidmap2")
-			expectDpkgNotInstalled("nfs-common")
-
-			Expect(findProcessState("nfsv3driver")).To(Equal(""))
-		})
-	})
-
-	Context("when another process has a dpkg lock", func() {
-
-		BeforeEach(func() {
-			cmd := exec.Command("bosh", "-d", "bosh_release_test", "ssh", "nfsv3driver", "-c", "sudo dpkg -P nfs-common")
-			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(session).Should(gexec.Exit(0))
-
-			cmd = exec.Command("bosh", "-d", "bosh_release_test", "ssh", "nfsv3driver", "-c", "sudo rm -f /tmp/lock_dpkg")
-			session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(session).Should(gexec.Exit(0))
-
-			cmd = exec.Command("bosh", "-d", "bosh_release_test", "scp", dpkgLockBuildPackagePath, "nfsv3driver:/tmp/lock_dpkg")
-			session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(session).Should(gexec.Exit(0), string(session.Out.Contents()))
-
-			cmd = exec.Command("bosh", "-d", "bosh_release_test", "ssh", "nfsv3driver", "-c", "sudo /tmp/lock_dpkg")
-			session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(session).Should(gbytes.Say("locked /var/lib/dpkg/lock"))
-		})
-
-		AfterEach(func() {
-			releaseDpkgLock()
-		})
-
-		It("should successfully dpkg install", func() {
-			unstubSleep()
-
-			cmd := exec.Command("bosh", "-d", "bosh_release_test", "ssh", "nfsv3driver", "-c", "sudo /var/vcap/jobs/nfsv3driver/bin/pre-start")
-			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(session).Should(gbytes.Say("dpkg: error: dpkg status database is locked by another process"))
-			releaseDpkgLock()
-			Eventually(session).Should(gexec.Exit(0))
-		})
-
-		It("should eventually timeout when the dpkg lock is not released in a reasonable time", func() {
-			cmd := exec.Command("bosh", "-d", "bosh_release_test", "ssh", "nfsv3driver", "-c", "sudo /var/vcap/jobs/nfsv3driver/bin/pre-start")
-			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(session).Should(gbytes.Say("dpkg: error: dpkg status database is locked by another process"))
-			Eventually(session, 6 * time.Minute, 1 * time.Second).Should(gexec.Exit(1))
-		})
 	})
 
 	Context("nfsv3driver drain", func() {


### PR DESCRIPTION
* compile nfs utils from source

[#186451769]

we want to stop shipping stemcell line depending debs for this release. Debs have to be installed via pre-start scripts and this is not a great solution in a bosh world. This PR changes the packaging script for nfs-debs to build the required tools from source. at this point it is yet to be tested if everything works as expected since there is a lot of uncertainty which dependencies (e.g. we ship krb5 debs) have been added for what reason. The current state of the packaging script is based on https://www.linuxfromscratch.org/blfs/view/svn/basicnet/nfs-utils.html and contains the logic to compile all required but none of the optional dependencies as it assumes that the optional dependencies required for ldap / krb / nfs4 support apply to the server side tools contained in the nfs-utils.

* Remove Stemcell dependencies

- This PR aims to test whether the Debian packages this release currently installs are really required in order for NFS to run
- Our preliminary investigation suggests these packages were once needed when Stemcells didn't have them.
- Another hypothesis is that some packages aimed to support other features that never made into this release (or were once present but no longer are)

* update path for new self compiled dependencies

the required mount.nfs binaries changed location when we started to compile from source

* upload missing blob

* update for clang env vars

* fix path for includes

some headers couldn't be found because the value for BOSH_INSTALL_TARGET doesn't end in a `/`.

the packaging missed the `make install` call to install the compiled binaries into BOSH_INSTALL_TARGET

* pin back nfs-utils to 2.6.2 for xenial support

nfs-utils 2.6.3 introduced the usage of `getrandom` which is a c function that exposes kernel functionality. while the kernel functionality is available in the 4.15 kernel of the xenial stemcell, the c function is not available in the stemcells libc. The mentioned issue breaks compilation of the sqlite3_backend in nfs-utils because `getrandom` is not defined. While `getrandom` is used only in one place within the whole codebase, and attempts to patch in a getrandom function succesfully compiled, it seems to be safer to pin back the nfs utils version until xenial is fully out of support.

* upload the blob...

* remove debian package installation logic

[ #186433296 ]

these lines are obsolete since we started compiling the nfs-utils from source.

* mount will look for helpers in /sbin

[ #186433296 ]

mount.nfs is not located in /sbin since we started compiling from source.

fixup issues when running mount via nfsdriver, the helper was not found in the packages dir

* remove commented out parts of packaging script

[ #186433296 ]

these were used for manual testing

flyby: update comments to specify the package that is actually compiled

* add compilation of rbcbind

it is required to mount nfsv3 mounts. Without it, the mount will fail.

* add rpc statd

[ #186433296 ]

rpc statd is required to run for nfsv3 mounts to work. addtionally rpc-bind is a runtime dependency that is required for nfsv3 mounts to work.

* fix templating errors preventing start

[#186433296]

* start rpcbind before starting statd

statdt requires rpcbind to be running in the background. add log output for current state / execution

* set LD_LIBRARY_PATH

currently starting rpcstatd fails because it cannot find the libtirpc.so.3.

this is most probably happening because of the non default install location for our packages.

fixes:
```
nfsv3driver/236135ea-84d1-441e-8e25-8ab606fa19d9:/var/vcap/bosh_ssh/bosh_e99a33b5d6034d4# LD_LIBRARY_PATH=/var/vcap/packages/nfs-debs/lib ldd  /var/vcap/packages/nfs-debs/sbin/rpcbind
        linux-vdso.so.1 =>  (0x00007ffd3e7f3000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f01969ac000)
        libtirpc.so.3 => /var/vcap/packages/nfs-debs/lib/libtirpc.so.3 (0x00007f0196784000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f01963ba000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f0196bc9000)
nfsv3driver/236135ea-84d1-441e-8e25-8ab606fa19d9:/var/vcap/bosh_ssh/bosh_e99a33b5d6034d4# ldd  /var/vcap/packages/nfs-debs/sbin/rpcbind
        linux-vdso.so.1 =>  (0x00007ffc7b1e0000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f90ca23b000)
        libtirpc.so.3 => not found
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f90c9e71000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f90ca458000)

```

---------