### PR TITLE
split monit jobs for rpc.statd and rpcbind  v5

### DIFF
--- a/jobs/nfsv3driver/monit
+++ b/jobs/nfsv3driver/monit
@@ -10,5 +10,10 @@ check process statd matching rpc.statd
   stop program "/var/vcap/jobs/nfsv3driver/bin/statd_ctl stop"
   if failed port <%= p("nfsv3driver.statd_port") %> then restart
   group vcap
+check process rpcbind matching rpcbind
+  start program "/var/vcap/jobs/nfsv3driver/bin/rpcbind_ctl start"
+  stop program "/var/vcap/jobs/nfsv3driver/bin/rpcbind_ctl stop"
+  if failed port 111 then restart
+  group vcap
 <% end %>
 

--- a/jobs/nfsv3driver/spec
+++ b/jobs/nfsv3driver/spec
@@ -12,6 +12,7 @@ templates:
   start.sh.erb: bin/start.sh
   drain.erb: bin/drain
   statd.erb: bin/statd_ctl
+  rpcbind.erb: bin/rpcbind_ctl
 
 packages:
 - nfs-debs

--- a/jobs/nfsv3driver/templates/rpcbind.erb
+++ b/jobs/nfsv3driver/templates/rpcbind.erb
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p /var/vcap/sys/log/statd
+exec 1>> /var/vcap/sys/log/statd/rpcbind.log
+exec 2>> /var/vcap/sys/log/statd/rpcbind.err.log
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/var/vcap/packages/nfs-debs/lib
+echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ `basename $0` $* --------------" | tee /dev/stderr
+
+case $1 in
+  start)
+    echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ starting rpcbind  --------------" | tee /dev/stdout
+    /var/vcap/packages/nfs-debs/sbin/rpcbind 
+  ;;
+  stop)
+    echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ stopping rpcbind  --------------" | tee /dev/stdout
+    pkill rpcbind
+  ;;
+  *)
+    echo "Usage: rpcbind_ctl {start|stop}"
+  ;;
+esac

--- a/jobs/nfsv3driver/templates/statd.erb
+++ b/jobs/nfsv3driver/templates/statd.erb
@@ -11,25 +11,18 @@ echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ `basename $0` $* ----------
 case $1 in
   start)
     mkdir -p /var/vcap/data/rpc_statd/sm
-
     if [[ ! -f /sbin/sm-notify ]]; then
       ln -s /var/vcap/packages/nfs-debs/sbin/sm-notify /sbin/sm-notify
     fi
-
-    echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ starting rpcbind  --------------" | tee /dev/stdout
-    /var/vcap/packages/nfs-debs/sbin/rpcbind 
     echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ starting statd  --------------" | tee /dev/stdout
     /var/vcap/packages/nfs-debs/sbin/rpc.statd -p <%= p("nfsv3driver.statd_port") %> -P /var/vcap/data/rpc_statd
-    ;;
-
+  ;;
   stop)
     echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ stopping rpcbind  --------------" | tee /dev/stdout
     pkill rpc.statd
-    echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ stopping rpcbind  --------------" | tee /dev/stdout
-    pkill rpcbind
-    ;;
+  ;;
 
   *)
     echo "Usage: statd_ctl {start|stop}"
-    ;;
+  ;;
 esac


### PR DESCRIPTION
currently the rpc.statd monit job does also track rpcbind and will restart rpcbind when rpc.statd fails. But we do not know if rpc.statd will actually crash if rpcbind fails. Currently nothing would restart rpcbind if it were to fail by itself. This splits out the logic to restart rpcbind from the rpc.statd ctl so we can manage it independently.