### PR TITLE
drain.erb - change rep check to use an integer (count) for the rep test

### DIFF
--- a/jobs/nfsv3driver/templates/drain.erb
+++ b/jobs/nfsv3driver/templates/drain.erb
@@ -24,7 +24,7 @@ heartbeat() {
 
 wait_for_apps_to_be_evacuated() {
     for i in {1..90}; do
-        if pgrep -x "rep" > /dev/null; then
+        if [ $(( $(pgrep -cx "rep") )) -gt 0  ]; then
             echo "waiting for rep..."
             sleep 10
         else


### PR DESCRIPTION
Here's my proposed fix (needs testing). Instead of testing for no output, this just gets an integer value from pgrep for the number of matching processes and uses that with an integer comparison.