### PR TITLE
Change nfsv3driver statd default port to `41793`

### DIFF
--- a/jobs/nfsv3driver/spec
+++ b/jobs/nfsv3driver/spec
@@ -25,7 +25,7 @@ consumes:
 properties:
   nfsv3driver.statd_port:
     description: "port rpc-statd listens on"
-    default: 60000
+    default: 41_793
   nfsv3driver.listen_addr:
     description: "address nfsv3driver listens on"
     default: "127.0.0.1:7589"


### PR DESCRIPTION
- The current default port `60000` is an ephemeral port and if another process happens to be already using it, `statd` will fail to start
- We will change the default port to `41793` which is a registered port apparently not yet [registered for use](https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Registered_ports).