### PR TITLE
use newest cf-cli available

### DIFF
--- a/jobs/nfsbrokerpush/templates/deploy.sh.erb
+++ b/jobs/nfsbrokerpush/templates/deploy.sh.erb
@@ -1,8 +1,8 @@
 #!/bin/bash -eu
 
-export PATH="/var/vcap/packages/cf-cli-6-linux/bin:$PATH"
-export PATH="/var/vcap/packages/cf-cli-7-linux/bin:$PATH"
 export PATH="/var/vcap/packages/cf-cli-8-linux/bin:${PATH}"
+export PATH="/var/vcap/packages/cf-cli-7-linux/bin:${PATH}"
+export PATH="/var/vcap/packages/cf-cli-6-linux/bin:${PATH}"
 export CF_HOME=/var/vcap/data/nfsbrokerpush_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 6 | head -n 1)/
 export CF_DIAL_TIMEOUT=<%= p('nfsbrokerpush.cf.dial_timeout') %>
 
@@ -117,7 +117,11 @@ function push_app() {
   LATEST_STACK=$( cf stacks | grep linux | cut -f1 -d' ' | sort -u | tail -1 )
   pushd /var/vcap/packages/nfsbroker > /dev/null
     set +e
-      cf push "${APP_NAME}" -i 1 -s ${LATEST_STACK}
+      REDACT_ENV=""
+      if cf push --help | grep -- '--redact-env'; then
+        REDACT_ENV="--redact-env"
+      fi
+      cf push "${APP_NAME}" -i 1 -s ${LATEST_STACK} ${REDACT_ENV}
       exit_code=$?
     set -e
 


### PR DESCRIPTION
[#187045997]

PATH load order is left to right:

```
❯ ls -la */
1/:
09:32 .
09:32 ..
09:32 bin

2/:
09:32 .
09:32 ..
09:32 bin

3/:

09:32 .
09:32 ..
09:32 bin

❯ which bin;  echo $?
1

❯ export PATH=$PATH:$(pwd)/1:$(pwd)/2:$(pwd)/3

❯ which bin
.../workspace/tmp/1/bin
```

so currently the push errand would use the oldest available cf cli.

fly-by:
- use --redact-env var flag if it is available to avoid leaking credentials that are set as env vars in the app.