### PR TITLE
Output rpcbind and statd logs to a sensible place

### DIFF
--- a/jobs/nfsv3driver/templates/rpcbind.erb
+++ b/jobs/nfsv3driver/templates/rpcbind.erb
@@ -2,9 +2,9 @@
 
 set -e
 
-mkdir -p /var/vcap/sys/log/statd
-exec 1>> /var/vcap/sys/log/statd/rpcbind.log
-exec 2>> /var/vcap/sys/log/statd/rpcbind.err.log
+mkdir -p /var/vcap/sys/log/nfsv3driver
+exec 1>> /var/vcap/sys/log/nfsv3driver/rpcbind.stdout.log
+exec 2>> /var/vcap/sys/log/nfsv3driver/rpcbind.stderr.log
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/var/vcap/packages/nfs-debs/lib
 echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ `basename $0` $* --------------" | tee /dev/stderr
 

--- a/jobs/nfsv3driver/templates/statd.erb
+++ b/jobs/nfsv3driver/templates/statd.erb
@@ -2,9 +2,9 @@
 
 set -e
 
-mkdir -p /var/vcap/sys/log/statd
-exec 1>> /var/vcap/sys/log/statd/statd.log
-exec 2>> /var/vcap/sys/log/statd/statd.err.log
+mkdir -p /var/vcap/sys/log/nfsv3driver
+exec 1>> /var/vcap/sys/log/nfsv3driver/statd.stdout.log
+exec 2>> /var/vcap/sys/log/nfsv3driver/statd.stderr.log
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/var/vcap/packages/nfs-debs/lib
 echo "[$(date  +%Y-%m-%dT%H:%M:%S.%NZ)] ------------ `basename $0` $* --------------" | tee /dev/stderr
 


### PR DESCRIPTION
Logs for rpcbind found in `/var/vcap/sys/log/nfsv3driver/rpcbind.stdout.log` and `/var/vcap/sys/log/nfsv3driver/rpcbind.stderr.log`
Logs for statd found in `/var/vcap/sys/log/nfsv3driver/statd.stdout.log` and `/var/vcap/sys/log/nfsv3driver/statd.stderr.log`