### PR TITLE
Remove unneeded packages for nfs-debs

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,6 @@ berkeleydb/db-5.3.28.tar.gz:
   size: 35090431
   object_id: 3ad9234b-50b7-4f58-7d46-d3569f90d3d6
   sha: fa3f8a41ad5101f43d08bc0efb6241c9b6fc1ae9
-nfs-debs/libevent-2.1.8-stable.tar.gz:
-  size: 1026485
-  object_id: 9b8c7244-3eaf-4dcb-6724-e50fbf2ff387
-  sha: sha256:965cc5a8bb46ce4199a47e9b2c9e1cae3b137e8356ffdad6d94d3b9069b71dc2
 nfs-debs/libtirpc-1.3.5.tar.gz:
   size: 257976
   object_id: 2c1a29ff-8495-4cae-6d7b-183680e67c78
@@ -18,10 +14,6 @@ nfs-debs/rpcbind-1.2.6-2build1-0-gd4047c3303d327fc59a869a7243132cb01aa0314.tar.g
   size: 163516
   object_id: 14a004b1-cfb6-4105-794f-5d448325582c
   sha: sha256:59778e27a97a44887ef5a1ce6c246bc1fcfb87a42f834a70145f03cb95868b5b
-nfs-debs/rpcsvc-proto-1.4.4.tar.xz:
-  size: 168648
-  object_id: 4e8c8dcd-97a2-4855-5bb2-34df28452116
-  sha: sha256:81c3aa27edb5d8a18ef027081ebb984234d5b5860c65bd99d4ac8f03145a558b
 nfs-debs/util-linux-2.40.2.tar.gz:
   size: 14941746
   object_id: 92de9700-16c7-4101-75d2-7171a78209ba

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -22,14 +22,6 @@ nfs-debs/rpcsvc-proto-1.4.4.tar.xz:
   size: 168648
   object_id: 4e8c8dcd-97a2-4855-5bb2-34df28452116
   sha: sha256:81c3aa27edb5d8a18ef027081ebb984234d5b5860c65bd99d4ac8f03145a558b
-nfs-debs/sqlite-3.46.0.tar.gz:
-  size: 13087894
-  object_id: d6f36237-3d99-4e27-5caf-ab758d85f13d
-  sha: sha256:eef903136896137fc9916b41b0182818203591c3d4e1313751ba875a9037d482
-nfs-debs/tcl8.6.14-src.tar.gz:
-  size: 11627322
-  object_id: cab5205b-9f36-4bb4-5f30-02104172f593
-  sha: sha256:5880225babf7954c58d4fb0f5cf6279104ce1cd6aa9b71e9a6322540e1c4de66
 nfs-debs/util-linux-2.40.2.tar.gz:
   size: 14941746
   object_id: 92de9700-16c7-4101-75d2-7171a78209ba

--- a/packages/nfs-debs/packaging
+++ b/packages/nfs-debs/packaging
@@ -2,33 +2,6 @@
 
 set -e
 
-#required to compile sqlite on xenial, configure fails without
-tar -xzf nfs-debs/tcl*.tar.gz
-pushd ${BOSH_COMPILE_TARGET}/tcl*/unix
-./configure   --prefix=${BOSH_INSTALL_TARGET}
-make
-make install
-export PATH=$BOSH_INSTALL_TARGET/bin:$PATH
-popd
-echo "TCL done"
-
-tar --one-top-level -xzf nfs-debs/sqlite-*.tar.gz
-pushd ${BOSH_COMPILE_TARGET}/sqlite-*/
-./configure \
-  --prefix=${BOSH_INSTALL_TARGET}     \
-  --disable-static  \
-  --enable-fts{4,5} \
-  CPPFLAGS="-DSQLITE_ENABLE_COLUMN_METADATA=1 \
-  -DSQLITE_ENABLE_UNLOCK_NOTIFY=1   \
-  -DSQLITE_ENABLE_DBSTAT_VTAB=1     \
-  -DSQLITE_SECURE_DELETE=1          \
-  -DSQLITE_ENABLE_FTS3_TOKENIZER=1"
-  make
-  make install
-  popd
-  echo "SQLITE done"
-
-
 # libevent
 tar -xzf nfs-debs/libevent-*.tar.gz
 pushd ${BOSH_COMPILE_TARGET}/libevent-*-stable/
@@ -126,7 +99,7 @@ pushd  ${BOSH_COMPILE_TARGET}/nfs-utils-*/
   --sbindir=${BOSH_INSTALL_TARGET}/sbin    \
   --disable-nfsv4        \
   --disable-gss          \
-  LIBS="-L${BOSH_INSTALL_TARGET}/lib -L${BOSH_INSTALL_TARGET}/lib/sqlite3.40.0 -lmount -levent_core  -lsqlite3 -ltirpc"
+  LIBS="-L${BOSH_INSTALL_TARGET}/lib -lmount -levent_core -ltirpc"
   make
   make install
 

--- a/packages/nfs-debs/packaging
+++ b/packages/nfs-debs/packaging
@@ -2,26 +2,6 @@
 
 set -e
 
-# libevent
-tar -xzf nfs-debs/libevent-*.tar.gz
-pushd ${BOSH_COMPILE_TARGET}/libevent-*-stable/
-# no binary 'python' on $PATH, but python3 is available
-sed -i 's/python/&3/' event_rpcgen.py
-./configure --prefix=${BOSH_INSTALL_TARGET} --disable-static
-make
-make install
-popd
-echo "LIBEVENT done"
-
-# rpcsvc-proto
-tar -xf nfs-debs/rpcsvc-proto-*.tar.xz
-pushd ${BOSH_COMPILE_TARGET}/rpcsvc-proto-*/
-./configure --prefix=${BOSH_INSTALL_TARGET} --sysconfdir=${BOSH_INSTALL_TARGET}/etc
-make
-make install
-popd
-echo "RPCSVC done"
-
 #libtirpc
 tar --one-top-level -xzf nfs-debs/libtirpc-*.tar.gz
 pushd  ${BOSH_COMPILE_TARGET}/libtirpc-*/
@@ -32,8 +12,8 @@ pushd  ${BOSH_COMPILE_TARGET}/libtirpc-*/
   --disable-gssapi 
   make
   make install
-  popd 
-  echo "LIBTIRPC done"
+popd
+echo "LIBTIRPC done"
 
 #linux-utils
 tar --one-top-level -xzf nfs-debs/util-linux-*.tar.gz
@@ -50,10 +30,8 @@ pushd ${BOSH_COMPILE_TARGET}/util-linux-*/
   --docdir=${BOSH_INSTALL_TARGET}/doc/util-linux   \
   --enable-libblkid   \
   --enable-libmount   \
-  --enable-libuuid   \
   --enable-blkid   \
   --enable-mount   \
-  --enable-uuid \
   --enable-shared   \
   --disable-all-programs   \
   --without-python
@@ -73,14 +51,13 @@ export TIRPC_LIBS="-L${BOSH_INSTALL_TARGET}/lib -I${BOSH_INSTALL_TARGET}/include
 
 tar --one-top-level -xzf nfs-debs/rpcbind-*.tar.gz
 pushd  ${BOSH_COMPILE_TARGET}/rpcbind-*/
-sed -i "/servname/s:rpcbind:sunrpc:" src/rpcbind.c
 
 ./configure \
-  --prefix=${BOSH_INSTALL_TARGET}/                                \
-  --bindir=${BOSH_INSTALL_TARGET}/sbin                             \
-  --with-rpcuser=root                            \
-  --enable-warmstarts                            \
-  --without-systemdsystemunitdir \
+  --prefix=${BOSH_INSTALL_TARGET}/         \
+  --bindir=${BOSH_INSTALL_TARGET}/sbin     \
+  --with-rpcuser=root                      \
+  --enable-warmstarts                      \
+  --without-systemdsystemunitdir           \
   LIBS="-L${BOSH_INSTALL_TARGET}/lib -ltirpc"
   make
   make install
@@ -99,7 +76,8 @@ pushd  ${BOSH_COMPILE_TARGET}/nfs-utils-*/
   --sbindir=${BOSH_INSTALL_TARGET}/sbin    \
   --disable-nfsv4        \
   --disable-gss          \
-  LIBS="-L${BOSH_INSTALL_TARGET}/lib -lmount -levent_core -ltirpc"
+  --disable-uuid         \
+  LIBS="-L${BOSH_INSTALL_TARGET}/lib -lmount -ltirpc"
   make
   make install
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
- Remove TCL
- Remove sqlite
- Remove libevent
- Remove rpcsvc-proto

Without these packages, I was able to deploy to cf-deployment and pass cf-volume-services-acceptance-tests.


Backward Compatibility
---------------
Breaking Change? **No**
