### PR TITLE
Update BBR lock/unlock dependencies

### DIFF
--- a/jobs/nfsbroker-bbr-lock/templates/metadata.sh.erb
+++ b/jobs/nfsbroker-bbr-lock/templates/metadata.sh.erb
@@ -8,6 +8,10 @@ backup_should_be_locked_before:
   release: credhub
 - job_name: cloud_controller_ng
   release: capi
+- job_name: cc-worker
+  release: capi
+- job_name: scheduler
+  release: capi
 
 restore_should_be_locked_before:
 - job_name: uaa
@@ -15,4 +19,8 @@ restore_should_be_locked_before:
 - job_name: credhub
   release: credhub
 - job_name: cloud_controller_ng
+  release: capi
+- job_name: cc-worker
+  release: capi
+- job_name: scheduler
   release: capi"


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->

This PR updated the BBR manifest generated by the bbr-smbbroker job to add the
CAPI jobs to the backup_should_be_locked_before and restore_should_be_locked_before settings
to fix an issue where DRATs occasionally fails due to a post-restore unlock
sequencing issue.

See https://github.com/cloudfoundry/disaster-recovery-acceptance-tests/issues/326 for more details.

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
