### PR TITLE
Fix credhub security group for nfsbroker push

### DIFF
--- a/jobs/nfsbrokerpush/templates/deploy.sh.erb
+++ b/jobs/nfsbrokerpush/templates/deploy.sh.erb
@@ -62,6 +62,7 @@ function create_credhub_security_group() {
   cf create-security-group credhub_open /var/vcap/jobs/nfsbrokerpush/credhub.json
   cf update-security-group credhub_open /var/vcap/jobs/nfsbrokerpush/credhub.json
   cf bind-security-group credhub_open $ORG --space $SPACE
+  cf bind-security-group credhub_open $ORG --space $SPACE --lifecycle staging
 }
 
 function create_manifest() {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Default lifecycle is "running", but credhub access is also required for "staging" (without, you will get "ERR panic: Get "https://credhub.service.cf.internal:8844/info": dial tcp 10.0.1.27:8844: connect: connection refused" during nfsbroker push)


Backward Compatibility
---------------
Breaking Change? No
