### PR TITLE
Fix bbr metadata.sh.erb

### DIFF
--- a/jobs/nfsbroker-bbr-lock/templates/metadata.sh.erb
+++ b/jobs/nfsbroker-bbr-lock/templates/metadata.sh.erb
@@ -8,9 +8,9 @@ backup_should_be_locked_before:
   release: credhub
 - job_name: cloud_controller_ng
   release: capi
-- job_name: cc-worker
+- job_name: cloud_controller_worker
   release: capi
-- job_name: scheduler
+- job_name: cc_deployment_updater
   release: capi
 
 restore_should_be_locked_before:
@@ -20,7 +20,7 @@ restore_should_be_locked_before:
   release: credhub
 - job_name: cloud_controller_ng
   release: capi
-- job_name: cc-worker
+- job_name: cloud_controller_worker
   release: capi
-- job_name: scheduler
+- job_name: cc_deployment_updater
   release: capi"


### PR DESCRIPTION
* names were instance_group names, but bbr expects job names

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fix bosh backup and restore metadata: "cc-worker" and "scheduler" are instance_group names, but bbr expects job names.

Backward Compatibility
---------------
Breaking Change? **No**
