### PR TITLE
Restart rpc group as asked by in man pages

### DIFF
--- a/jobs/nfsv3driver/monit
+++ b/jobs/nfsv3driver/monit
@@ -9,18 +9,20 @@ check process statd matching rpc.statd
   start program "/var/vcap/jobs/nfsv3driver/bin/statd_ctl start"
   stop program "/var/vcap/jobs/nfsv3driver/bin/statd_ctl stop"
   group vcap
+  group rpc
   if failed
      host 127.0.0.1
      port <%= p("nfsv3driver.statd_port") %>
      for 3 cycles
-  then restart
+  then exec "/var/vcap/bosh/bin/monit -g rpc restart"
 check process rpcbind matching rpcbind
   start program "/var/vcap/jobs/nfsv3driver/bin/rpcbind_ctl start"
   stop program "/var/vcap/jobs/nfsv3driver/bin/rpcbind_ctl stop"
   group vcap
+  group rpc
   if failed
      host 127.0.0.1
      port 111
      for 3 cycles
-  then restart
+  then exec "/var/vcap/bosh/bin/monit -g rpc restart"
 <% end %>


### PR DESCRIPTION
Both rpcbind + statd, according to https://man7.org/linux/man-pages/man8/rpcbind.8.html, needs to be restarted together.

There is no action to do a group restart, so using monit cli https://mmonit.com/monit/documentation/monit.html#SERVICE-GROUPS invoked via the exec action https://mmonit.com/monit/documentation/monit.html#ACTION to restart the new `rpc` group that rpcbind and statd are part of.