### PR TITLE
Bump rspec-its -> 2.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,18 +8,18 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.0)
+    rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.1)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-its (1.3.0)
-      rspec-core (>= 3.0.0)
-      rspec-expectations (>= 3.0.0)
+    rspec-its (2.0.0)
+      rspec-core (>= 3.13.0)
+      rspec-expectations (>= 3.13.0)
     rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.1)
+    rspec-support (3.13.2)
     semi_semantic (1.2.0)
 
 PLATFORMS
@@ -32,4 +32,4 @@ DEPENDENCIES
   rspec-its
 
 BUNDLED WITH
-   2.5.17
+   2.5.23


### PR DESCRIPTION
- [V] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
The current version for rspec-its is older than a year.
Bumping rspec-its -> 2.0.0 to fit the SAP requirements for OSS compliance.

The tests have been executed locally by executing 'scripts/test-in-docker.bash'. The tests' output did not change after bumping the versions.

Executed commands:
bundle update rspec-its