### PR TITLE
cleanup time format property

### DIFF
--- a/jobs/nfsbrokerpush/spec
+++ b/jobs/nfsbrokerpush/spec
@@ -123,6 +123,3 @@ properties:
   nfsbrokerpush.log_level:
     description: "nfsbroker log level"
     default: "info"
-  nfsbrokerpush.log_time_format:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "rfc3339"

--- a/jobs/nfsbrokerpush/templates/start.sh.erb
+++ b/jobs/nfsbrokerpush/templates/start.sh.erb
@@ -30,5 +30,5 @@ bin/nfsbroker --listenAddr="0.0.0.0:$PORT" \
               --credhubURL="<%= credhub_url %>" \
               --storeID="<%= p('nfsbrokerpush.store_id') %>" \
               --logLevel="<%= p("nfsbrokerpush.log_level") %>" \
-              --timeFormat="<%= p("nfsbrokerpush.log_time_format") %>" \
+              --timeFormat="rfc3339" \
               --allowedOptions="<%= allowed_options %>"

--- a/jobs/nfsv3driver/spec
+++ b/jobs/nfsv3driver/spec
@@ -42,9 +42,6 @@ properties:
   nfsv3driver.log_level:
     description: "nfsv3driver log level"
     default: "info"
-  nfsv3driver.log_time_format:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "rfc3339"
   nfsv3driver.disable:
     description: "disable nfsv3driver"
     default: false

--- a/jobs/nfsv3driver/templates/start.sh.erb
+++ b/jobs/nfsv3driver/templates/start.sh.erb
@@ -46,7 +46,7 @@ exec /var/vcap/packages/nfsv3driver/bin/nfsv3driver \
   --driversPath="<%= p("nfsv3driver.driver_path") %>" \
   --mountDir="<%= p("nfsv3driver.cell_mount_path") %>" \
   --logLevel="<%= p("nfsv3driver.log_level") %>" \
-  --timeFormat="<%= p("nfsv3driver.log_time_format") %>" \
+  --timeFormat="rfc3339" \
   --mapfsPath="/var/vcap/packages/map-fs/bin/mapfs" \
   >> $LOG_DIR/nfsv3driver.stdout.log \
   2>> $LOG_DIR/nfsv3driver.stderr.log

--- a/spec/jobs/nfsbrokerpush/manifest_yml_spec.rb
+++ b/spec/jobs/nfsbrokerpush/manifest_yml_spec.rb
@@ -31,7 +31,6 @@ describe 'nfsbrokerpush job' do
             },
             "store_id" => "some-store-id",
             "log_level" => "some-log-level",
-            "log_time_format" => "some-log-time-format",
             "app_name" => "super-cool-app",
             "app_domain" => "cf-domain.test",
             "username" => "jane-doe",
@@ -64,7 +63,6 @@ describe 'nfsbrokerpush job' do
           "nfsbrokerpush" => {
             "store_id" => "some-store-id",
             "log_level" => "some-log-level",
-            "log_time_format" => "some-log-time-format",
             "app_name" => "super-cool-app",
             "app_domain" => "cf-domain.test",
             "username" => "jane-doe",

--- a/spec/jobs/nfsbrokerpush/start_sh_spec.rb
+++ b/spec/jobs/nfsbrokerpush/start_sh_spec.rb
@@ -31,7 +31,6 @@ describe 'nfsbrokerpush job' do
             },
             "store_id" => "some-store-id",
             "log_level" => "some-log-level",
-            "log_time_format" => "some-log-time-format",
           }
         }
       end
@@ -45,7 +44,6 @@ describe 'nfsbrokerpush job' do
         expect(tpl_output).not_to include("--uaaClientSecret=\"client-secret\"")
         expect(tpl_output).to include("--servicesConfig=\"./services.json\"")
         expect(tpl_output).to include("--logLevel=\"some-log-level\"")
-        expect(tpl_output).to include("--timeFormat=\"some-log-time-format\"")
         expect(tpl_output).to include("--allowedOptions=\"source,uid,gid,auto_cache,readonly,version,mount,cache\"")
       end
     end


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
cleanup time format property

```
Before:
{"timestamp":"1749847427.605977774","source":"nfs-driver-server","message":"nfs-driver-server.server.handle-list.end","log_level":1,"data":{"session":"2.2"}}
compute/37da85bd-752b-4af5-aac8-501fed9d1f09:/var/vcap/sys/log/nfsv3driver$ 

After:
{"timestamp":"2025-06-13T22:03:28.040092421Z","level":"info","source":"nfs-driver-server","message":"nfs-driver-server.server.handle-list.end","data":{"session":"2.2"}}
compute/029ea4c4-ee47-4fb1-a85c-a2583d24367d:/var/vcap/sys/log/nfsv3driver$

before:
   2025-06-18T20:39:40.60+0000 [APP/PROC/WEB/0] OUT {"timestamp":"1750279180.604760408","source":"nfsbroker","message":"nfsbroker.is-there-a-proxy.start","log_level":1,"data":{"session":"1"}}
after:
   2025-06-18T21:09:18.77+0000 [APP/PROC/WEB/0] OUT {"timestamp":"2025-06-18T21:09:18.777534116Z","level":"info","source":"nfsbroker","message":"nfsbroker.starting","data":{}}
```


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
