### PR TITLE
Update bbr-smbbroker's bbr metadata to be overridable with a bosh pro…

### DIFF
--- a/jobs/nfsbroker-bbr-lock/spec
+++ b/jobs/nfsbroker-bbr-lock/spec
@@ -11,3 +11,31 @@ consumes:
   - name: nfsbrokerpush
     type: nfsbrokerpush
 
+properties:
+  bbr.metadata:
+    description: "BBR Metadata"
+    default: |
+      ---
+      backup_should_be_locked_before:
+      - job_name: uaa
+        release: uaa
+      - job_name: credhub
+        release: credhub
+      - job_name: cloud_controller_ng
+        release: capi
+      - job_name: cloud_controller_worker
+        release: capi
+      - job_name: cc_deployment_updater
+        release: capi
+
+      restore_should_be_locked_before:
+      - job_name: uaa
+        release: uaa
+      - job_name: credhub
+        release: credhub
+      - job_name: cloud_controller_ng
+        release: capi
+      - job_name: cloud_controller_worker
+        release: capi
+      - job_name: cc_deployment_updater
+        release: capi

--- a/jobs/nfsbroker-bbr-lock/templates/metadata.sh.erb
+++ b/jobs/nfsbroker-bbr-lock/templates/metadata.sh.erb
@@ -1,26 +1,3 @@
 #!/usr/bin/env bash
 
-echo "---
-backup_should_be_locked_before:
-- job_name: uaa
-  release: uaa
-- job_name: credhub
-  release: credhub
-- job_name: cloud_controller_ng
-  release: capi
-- job_name: cloud_controller_worker
-  release: capi
-- job_name: cc_deployment_updater
-  release: capi
-
-restore_should_be_locked_before:
-- job_name: uaa
-  release: uaa
-- job_name: credhub
-  release: credhub
-- job_name: cloud_controller_ng
-  release: capi
-- job_name: cloud_controller_worker
-  release: capi
-- job_name: cc_deployment_updater
-  release: capi"
+echo '<%= p("bbr.metadata") %>'

--- a/spec/jobs/nfsbroker-bbr-lock/bbr-metadata_spec.rb
+++ b/spec/jobs/nfsbroker-bbr-lock/bbr-metadata_spec.rb
@@ -1,0 +1,68 @@
+require 'rspec'
+require 'bosh/template/test'
+
+describe 'nfsbroker-bbr-lock job' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../../..')) }
+  let(:job) { release.job('nfsbroker-bbr-lock') }
+
+  let(:merged_manifest_properties) do
+    {}
+  end
+
+  describe 'bbr metadata' do
+    let(:template) { job.template('bin/bbr/metadata') }
+    let(:links) { [] }
+
+    subject(:script_output) do
+      `#{template.render(merged_manifest_properties, consumes: links)}`
+    end
+
+    describe 'when the property is not defined' do
+      it 'has a sane default' do
+        expect(script_output).to eq('---
+backup_should_be_locked_before:
+- job_name: uaa
+  release: uaa
+- job_name: credhub
+  release: credhub
+- job_name: cloud_controller_ng
+  release: capi
+- job_name: cloud_controller_worker
+  release: capi
+- job_name: cc_deployment_updater
+  release: capi
+
+restore_should_be_locked_before:
+- job_name: uaa
+  release: uaa
+- job_name: credhub
+  release: credhub
+- job_name: cloud_controller_ng
+  release: capi
+- job_name: cloud_controller_worker
+  release: capi
+- job_name: cc_deployment_updater
+  release: capi
+
+')
+      end
+    end
+    describe 'when the property is provided' do
+      before do
+        merged_manifest_properties['bbr'] = {
+          'metadata'=> '---
+  test: yaml
+  corn: banana
+'
+        }
+      end
+      it 'overrides the output' do
+        expect(script_output).to eq('---
+  test: yaml
+  corn: banana
+
+')
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Lets operators override the bbr config entirely.


Backward Compatibility
---------------
Breaking Change? no