### PR TITLE
add property to set cli path

### DIFF
--- a/jobs/nfsbroker-bbr-lock/templates/post-restore-unlock.sh.erb
+++ b/jobs/nfsbroker-bbr-lock/templates/post-restore-unlock.sh.erb
@@ -2,7 +2,7 @@
 set -euo pipefail
 set -x
 
-PATH="/var/vcap/packages/cf-cli-8-linux/bin:${PATH}"
+PATH="<%= link('nfsbrokerpush').p('nfsbrokerpush.cli_path') %>:${PATH}"
 
 API_ENDPOINT=https://api.<%= link('nfsbrokerpush').p('nfsbrokerpush.domain') %>
 ORG=<%= link('nfsbrokerpush').p('nfsbrokerpush.organization') %>

--- a/jobs/nfsbrokerpush/spec
+++ b/jobs/nfsbrokerpush/spec
@@ -31,6 +31,7 @@ provides:
     - nfsbrokerpush.space
     - nfsbrokerpush.app_name
     - nfsbrokerpush.skip_cert_verify
+    - nfsbrokerpush.cli_path
 
 properties:
   nfsbrokerpush.domain:
@@ -123,3 +124,6 @@ properties:
   nfsbrokerpush.log_level:
     description: "nfsbroker log level"
     default: "info"
+  nfsbrokerpush.cli_path:
+    description: "Path where the cf cli binary is stored"
+    default: "/var/vcap/packages/cf-cli-8-linux/bin"

--- a/jobs/nfsbrokerpush/templates/deploy.sh.erb
+++ b/jobs/nfsbrokerpush/templates/deploy.sh.erb
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export PATH="/var/vcap/packages/cf-cli-8-linux/bin:${PATH}"
+export PATH="<%= p('nfsbrokerpush.cli_path') %>:${PATH}"
 
 export CF_HOME=/var/vcap/data/nfsbrokerpush_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 6 | head -n 1)/
 export CF_DIAL_TIMEOUT=<%= p('nfsbrokerpush.cf.dial_timeout') %>


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
```
~/workspace/nfs-volume-release |cf-cli U:1| 
$ ./scripts/create-docker-container.bash 
Using default tag: latest
latest: Pulling from cloudfoundry/tas-runtime-build
Digest: sha256:51d101758bd0f9f6de09a6a47369657c98e6ad070471ca34ca493f2a0cbb2bc2
Status: Image is up to date for cloudfoundry/tas-runtime-build:latest
docker.io/cloudfoundry/tas-runtime-build:latest
Error response from daemon: No such container: nfs-volume-release-docker-container
root@18d0d44e37b9:/# repo/scripts/docker/test.bash 
Verifying: verify_go repo/src/code.cloudfoundry.org/nfsbroker
go version go1.25.7 linux/amd64
Verifying: verify_go_version_match_bosh_release repo
Verifying: verify_gofmt repo/src/code.cloudfoundry.org/nfsbroker
Verifying: verify_govet repo/src/code.cloudfoundry.org/nfsbroker
Verifying: verify_staticcheck repo/src/code.cloudfoundry.org/nfsbroker
Running Suite: Nfsbroker Main Suite - /repo/src/code.cloudfoundry.org/nfsbroker
===============================================================================
```


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
