### PR TITLE
Fix dangling NFS kernel mount on uid/gid validation error

### DIFF
--- a/src/code.cloudfoundry.org/nfsv3driver/mapfs_mounter.go
+++ b/src/code.cloudfoundry.org/nfsv3driver/mapfs_mounter.go
@@ -174,6 +174,17 @@ func (m *mapfsMounter) Mount(env dockerdriver.Env, remote string, target string,
 		mountOptions = mountOptions + ",vers=" + version
 	}
 
+	if uidok {
+		uid, err := strconv.ParseUint(uniformData(opts["uid"]), 10, 32)
+		if err != nil || uid <= 0 {
+			return dockerdriver.SafeError{SafeDescription: InvalidUidValueErrorMessage}
+		}
+		gid, err := strconv.ParseUint(uniformData(opts["gid"]), 10, 32)
+		if err != nil || gid <= 0 {
+			return dockerdriver.SafeError{SafeDescription: InvalidGidValueErrorMessage}
+		}
+	}
+
 	t := intermediateMount
 	if !uidok {
 		t = target
@@ -193,21 +204,8 @@ func (m *mapfsMounter) Mount(env dockerdriver.Env, remote string, target string,
 		// make sure the mapped user has read access to the directory before doing the mapfs mount
 		// this check is best effort--root may not be able to stat the directory, or the server may
 		// anonymize the owner UID.
-		uid, err := strconv.ParseUint(uniformData(opts["uid"]), 10, 32)
-		if err != nil {
-			return dockerdriver.SafeError{SafeDescription: InvalidUidValueErrorMessage}
-		}
-		if uid <= 0 {
-			return dockerdriver.SafeError{SafeDescription: InvalidUidValueErrorMessage}
-		}
-
-		gid, err := strconv.ParseUint(uniformData(opts["gid"]), 10, 32)
-		if err != nil {
-			return dockerdriver.SafeError{SafeDescription: InvalidGidValueErrorMessage}
-		}
-		if gid <= 0 {
-			return dockerdriver.SafeError{SafeDescription: InvalidGidValueErrorMessage}
-		}
+		uid, _ := strconv.ParseUint(uniformData(opts["uid"]), 10, 32)
+		gid, _ := strconv.ParseUint(uniformData(opts["gid"]), 10, 32)
 
 		st := syscall.Stat_t{}
 		err = m.syscallshim.Stat(intermediateMount, &st)

--- a/src/code.cloudfoundry.org/nfsv3driver/mapfs_mounter_test.go
+++ b/src/code.cloudfoundry.org/nfsv3driver/mapfs_mounter_test.go
@@ -456,12 +456,14 @@ var _ = Describe("MapfsMounter", func() {
 		})
 
 		DescribeTable("when uid is provided invalid values it should error", func(invalidUid interface{}) {
+			countBefore := fakeInvoker.InvokeCallCount()
 			opts["uid"] = invalidUid
 			err = subject.Mount(env, source, target, opts)
 			Expect(err).To(HaveOccurred())
 			_, ok := err.(dockerdriver.SafeError)
 			Expect(ok).To(BeTrue())
 			Expect(err.Error()).To(Equal("Invalid 'uid' option (0, negative, or non-integer)"))
+			Expect(fakeInvoker.InvokeCallCount()).To(Equal(countBefore), "mount must not be called when uid validation fails")
 
 		},
 			Entry("when uid is not an integer", "foo"),
@@ -471,12 +473,14 @@ var _ = Describe("MapfsMounter", func() {
 		)
 
 		DescribeTable("when gid is provided invalid values it should error", func(invalidGid interface{}) {
+			countBefore := fakeInvoker.InvokeCallCount()
 			opts["gid"] = invalidGid
 			err = subject.Mount(env, source, target, opts)
 			Expect(err).To(HaveOccurred())
 			_, ok := err.(dockerdriver.SafeError)
 			Expect(ok).To(BeTrue())
 			Expect(err.Error()).To(Equal("Invalid 'gid' option (0, negative, or non-integer)"))
+			Expect(fakeInvoker.InvokeCallCount()).To(Equal(countBefore), "mount must not be called when gid validation fails")
 
 		},
 			Entry("when gid is not an integer", "foo"),


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
When a Diego cell bind request included an invalid uid or gid (zero, negative, or non-integer), the kernel NFS mount was already established before the validation ran. The four early-return paths for parse/range errors returned a SafeError without calling umount on the intermediate mount point, leaving a dangling kernel mount and a 0777 directory under /var/vcap/data/volumes/nfs/<id>_mapfs on the host. This mount would persist until the cell was rebooted or cleaned manually, consuming kernel resources and potentially interfering with subsequent bind attempts to the same path.

Fix: move uid/gid validation to before the mount call. If validation fails at that point, no mount has occurred so no cleanup is needed. The post-mount block retains the stat-based read-access check and re-parses uid/gid inline (errors suppressed because validity is guaranteed by the pre-mount check). This approach eliminates the bug class entirely rather than adding umount cleanup to each error path, and aligns with the existing pattern where all other validations (LDAP, version, cache) happen before the mount.

Tests: existing invalid-uid/gid table tests now also assert that InvokeCallCount does not increase when validation fails, confirming the kernel mount is never attempted.


Backward Compatibility
---------------
Breaking Change? **No**

